### PR TITLE
Drift removal

### DIFF
--- a/CellEvoX/include/core/RunDataEngine.hpp
+++ b/CellEvoX/include/core/RunDataEngine.hpp
@@ -34,6 +34,8 @@ class RunDataEngine {
   void plotClonePhylogenyTree();
   void plotCloneCounts();
   void plotCloneLifespans();
+  void plotCloneGrowthAnimation();
+  void plotTumorReplay3D();
   void exportGenealogyToGexf(size_t num_cells_to_trace, const std::string& filename);
   void exportPhylogeneticTreeToGEXF(const std::string& filename);
   // void exportToCSV(const tbb::concurrent_vector<Cell>& cells, const std::string& output_file);

--- a/CellEvoX/include/systems/SimulationEngine.hpp
+++ b/CellEvoX/include/systems/SimulationEngine.hpp
@@ -19,6 +19,8 @@ struct SimulationConfig {
   double tau_step = 0.005;
   uint32_t seed = 42;
   size_t initial_population = 0;
+  // Well-mixed carrying-capacity scale. Spatial 3D crowding is controlled by
+  // max_local_density instead.
   size_t env_capacity = 0;
   size_t steps = 0;
   uint32_t stat_res = 1;
@@ -29,6 +31,7 @@ struct SimulationConfig {
   int verbosity = 2; // 0: off, 1: minimal, 2: full
   uint32_t phylogeny_num_cells_sampling = 100;
   float spatial_domain_size = 200.0f;
+  // Local carrying-capacity proxy for the spatial 3D model.
   float max_local_density = 8.0f;
   float sample_radius = 3.0f;
   float spring_constant = 0.5f;

--- a/CellEvoX/include/utils/SimulationConfig.hpp
+++ b/CellEvoX/include/utils/SimulationConfig.hpp
@@ -101,7 +101,13 @@ inline void printConfig(const SimulationConfig& config) {
   spdlog::info("Simulation type: {}", toString(config.sim_type));
   spdlog::info("Tau step: {:.3f}", config.tau_step);
   spdlog::info("Initial population: {}", config.initial_population);
-  spdlog::info("Environment capacity: {}", config.env_capacity);
+  if (config.sim_type == SimulationType::SPATIAL_3D_ABM) {
+    spdlog::info("Environment capacity (parsed, unused by 3D crowding): {}",
+                 config.env_capacity);
+  } else {
+    spdlog::info("Environment capacity (well-mixed carrying-capacity scale): {}",
+                 config.env_capacity);
+  }
   spdlog::info("Number of steps: {}", config.steps);
   spdlog::info("Statistics resolution: {}", config.stat_res);
   spdlog::info("Statistics resolution: {}", config.stat_res);

--- a/CellEvoX/scripts/animate_clone_growth_2d.py
+++ b/CellEvoX/scripts/animate_clone_growth_2d.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import math
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.animation as animation
+import matplotlib.gridspec as gridspec
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from snapshot_io import ANCESTOR_SIGNATURE, build_clone_timecourse, pick_top_clones, signature_depth
+
+
+BACKGROUND = "#0f1115"
+PANEL = "#171a21"
+GRID = "#2b313c"
+TEXT = "#f2f4f8"
+SECONDARY_TEXT = "#b3bac5"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Animate clone growth in 2D from CellEvoX run data.")
+    parser.add_argument("--input", required=True, help="Path to a simulation output directory")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output animation path (default: <input>/visualizations/clone_growth_2d.mp4)",
+    )
+    parser.add_argument("--fps", type=int, default=24, help="Animation frame rate")
+    parser.add_argument("--dpi", type=int, default=180, help="Output DPI")
+    parser.add_argument(
+        "--max-clones",
+        type=int,
+        default=14,
+        help="Maximum number of major clone bands to show before aggregating the tail",
+    )
+    parser.add_argument(
+        "--max-frames",
+        type=int,
+        default=220,
+        help="Resample long time series to at most this many animation frames",
+    )
+    return parser.parse_args()
+
+
+def default_output_path(run_dir: Path) -> Path:
+    return run_dir / "visualizations" / "clone_growth_2d.mp4"
+
+
+def prepare_writer(output_path: Path, fps: int) -> Tuple[animation.AbstractMovieWriter, Path]:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    suffix = output_path.suffix.lower()
+    if suffix == ".gif":
+        return animation.PillowWriter(fps=fps), output_path
+
+    if animation.writers.is_available("ffmpeg"):
+        return animation.FFMpegWriter(
+            fps=fps,
+            metadata={"title": "CellEvoX clone growth 2D"},
+            codec="libx264",
+            bitrate=2400,
+        ), output_path
+
+    fallback = output_path.with_suffix(".gif")
+    print(f"Warning: ffmpeg not available, saving GIF instead: {fallback}")
+    return animation.PillowWriter(fps=max(1, min(fps, 18))), fallback
+
+
+def resample_counts(counts_df: pd.DataFrame, max_frames: int) -> Tuple[np.ndarray, np.ndarray]:
+    generations = counts_df.index.to_numpy(dtype=float)
+    if len(generations) <= max_frames:
+        return generations, counts_df.to_numpy(dtype=float).T
+
+    sampled_generations = np.linspace(generations.min(), generations.max(), num=max_frames)
+    sampled_matrix = []
+    for column in counts_df.columns:
+        sampled_matrix.append(np.interp(sampled_generations, generations, counts_df[column].to_numpy(dtype=float)))
+    return sampled_generations, np.asarray(sampled_matrix)
+
+
+def build_tree_layout(metadata_df: pd.DataFrame) -> Tuple[Dict[str, Tuple[float, float]], List[Tuple[str, str]]]:
+    metadata = metadata_df.set_index("CloneSignature")
+    visible = [signature for signature in metadata.index if signature != "other"]
+    children: Dict[str, List[str]] = {signature: [] for signature in visible}
+    edges: List[Tuple[str, str]] = []
+
+    for signature in visible:
+        if signature == ANCESTOR_SIGNATURE:
+            continue
+        parent = str(metadata.loc[signature, "ParentSignature"])
+        if parent not in children:
+            parent = ANCESTOR_SIGNATURE
+        children[parent].append(signature)
+        edges.append((parent, signature))
+
+    for signature, clone_children in children.items():
+        clone_children.sort(
+            key=lambda child: (
+                metadata.loc[child, "FirstGeneration"],
+                -metadata.loc[child, "PeakCells"],
+                child,
+            )
+        )
+
+    positions: Dict[str, Tuple[float, float]] = {}
+    leaf_order: List[str] = []
+
+    def assign_order(node: str) -> None:
+        if not children.get(node):
+            leaf_order.append(node)
+            return
+        for child in children[node]:
+            assign_order(child)
+
+    assign_order(ANCESTOR_SIGNATURE)
+    y_lookup = {leaf: index for index, leaf in enumerate(leaf_order or [ANCESTOR_SIGNATURE])}
+
+    def assign_positions(node: str) -> float:
+        if not children.get(node):
+            y_coord = float(y_lookup.get(node, 0))
+            positions[node] = (float(signature_depth(node)), y_coord)
+            return y_coord
+
+        child_y = [assign_positions(child) for child in children[node]]
+        y_coord = float(sum(child_y) / len(child_y))
+        positions[node] = (float(signature_depth(node)), y_coord)
+        return y_coord
+
+    assign_positions(ANCESTOR_SIGNATURE)
+    return positions, edges
+
+
+def signature_display_text(signature: str) -> str:
+    if signature == ANCESTOR_SIGNATURE:
+        return "ancestor"
+    if signature == "other":
+        return "other"
+    parts = signature.split(",")
+    return parts[-1] if len(parts) > 1 else signature
+
+
+def draw_tree_panel(
+    ax: plt.Axes,
+    metadata_df: pd.DataFrame,
+    positions: Dict[str, Tuple[float, float]],
+    edges: List[Tuple[str, str]],
+    current_generation: float,
+    current_counts: Dict[str, float],
+) -> None:
+    ax.clear()
+    ax.set_facecolor(PANEL)
+    ax.set_title("Clone tree", color=TEXT, fontsize=15, loc="left", pad=10)
+    ax.axis("off")
+
+    metadata = metadata_df.set_index("CloneSignature")
+    max_current = max(current_counts.values()) if current_counts else 1.0
+
+    for parent, child in edges:
+        x_parent, y_parent = positions[parent]
+        x_child, y_child = positions[child]
+        child_birth = float(metadata.loc[child, "FirstGeneration"])
+        visible_alpha = 0.82 if child_birth <= current_generation else 0.10
+        ax.plot(
+            [x_parent, x_child],
+            [y_parent, y_child],
+            color=metadata.loc[child, "CloneColorHex"],
+            alpha=visible_alpha,
+            linewidth=2.4 if child_birth <= current_generation else 1.1,
+        )
+
+    for signature, (x_coord, y_coord) in positions.items():
+        row = metadata.loc[signature]
+        current_value = current_counts.get(signature, 0.0)
+        emerged = float(row["FirstGeneration"]) <= current_generation if not math.isnan(row["FirstGeneration"]) else False
+        alpha = 0.98 if emerged else 0.14
+        size = 80.0
+        if max_current > 0.0 and current_value > 0.0:
+            size += 650.0 * math.sqrt(current_value / max_current)
+        ax.scatter(
+            [x_coord],
+            [y_coord],
+            s=size,
+            color=row["CloneColorHex"],
+            alpha=alpha,
+            edgecolors="#0b0d11",
+            linewidths=1.0,
+            zorder=3,
+        )
+        if emerged or signature == ANCESTOR_SIGNATURE:
+            ax.text(
+                x_coord + 0.08,
+                y_coord,
+                signature_display_text(signature),
+                color=TEXT if emerged else SECONDARY_TEXT,
+                fontsize=9,
+                va="center",
+            )
+
+
+def draw_stats_panel(
+    ax: plt.Axes,
+    current_generation: float,
+    counts_map: Dict[str, float],
+    metadata_df: pd.DataFrame,
+) -> None:
+    ax.clear()
+    ax.set_facecolor(PANEL)
+    ax.axis("off")
+
+    total_cells = sum(counts_map.values())
+    active = {signature: value for signature, value in counts_map.items() if value > 0.5 and signature != "other"}
+    dominant_signature = max(active, key=active.get) if active else ANCESTOR_SIGNATURE
+    dominant_row = metadata_df.set_index("CloneSignature").loc[dominant_signature]
+    dominant_cells = counts_map.get(dominant_signature, 0.0)
+
+    text_lines = [
+        ("Generation", f"{current_generation:.1f}", TEXT),
+        ("Living cells", f"{int(round(total_cells)):,}".replace(",", " "), TEXT),
+        ("Active clones", str(len(active) or 1), TEXT),
+        (
+            "Dominant clone",
+            dominant_row["CloneLabel"],
+            dominant_row["CloneColorHex"],
+        ),
+        ("Dominant share", f"{(dominant_cells / total_cells * 100.0) if total_cells else 0.0:.1f}%", TEXT),
+    ]
+
+    y_coord = 0.92
+    ax.text(0.02, y_coord, "Current state", color=TEXT, fontsize=15, fontweight="bold", transform=ax.transAxes)
+    y_coord -= 0.12
+
+    for label, value, value_color in text_lines:
+        ax.text(0.02, y_coord, label, color=SECONDARY_TEXT, fontsize=10, transform=ax.transAxes)
+        ax.text(
+            0.02,
+            y_coord - 0.07,
+            value,
+            color=value_color,
+            fontsize=14,
+            fontweight="bold",
+            transform=ax.transAxes,
+        )
+        y_coord -= 0.19
+
+
+def render_clone_growth_animation(run_dir: Path, output_path: Path, fps: int, dpi: int, max_clones: int, max_frames: int) -> Path:
+    counts_df, metadata_df, _, _ = build_clone_timecourse(run_dir, prefer_bin=False)
+    counts_df, metadata_df = pick_top_clones(counts_df, metadata_df, max_clones=max_clones)
+
+    ordered_signatures = (
+        metadata_df.sort_values(
+            by=["IsAncestor", "FirstGeneration", "PeakCells", "CloneSignature"],
+            ascending=[False, True, False, True],
+        )["CloneSignature"].tolist()
+    )
+    counts_df = counts_df.reindex(columns=ordered_signatures, fill_value=0.0)
+    metadata_df = metadata_df.set_index("CloneSignature").loc[ordered_signatures].reset_index()
+
+    sampled_generations, sampled_matrix = resample_counts(counts_df, max_frames=max_frames)
+    colors = metadata_df["CloneColorHex"].tolist()
+    positions, edges = build_tree_layout(metadata_df)
+
+    fig = plt.figure(figsize=(15.5, 8.5), facecolor=BACKGROUND)
+    grid = gridspec.GridSpec(2, 2, figure=fig, width_ratios=[2.4, 1.1], height_ratios=[1.0, 0.72])
+    area_ax = fig.add_subplot(grid[:, 0])
+    tree_ax = fig.add_subplot(grid[0, 1])
+    stats_ax = fig.add_subplot(grid[1, 1])
+
+    cumulative_max = float(sampled_matrix.sum(axis=0).max()) if sampled_matrix.size else 1.0
+
+    def draw_frame(frame_index: int) -> None:
+        current_generation = float(sampled_generations[frame_index])
+        current_matrix = sampled_matrix[:, : frame_index + 1]
+        current_x = sampled_generations[: frame_index + 1]
+        current_counts = {
+            signature: float(sampled_matrix[idx, frame_index])
+            for idx, signature in enumerate(ordered_signatures)
+        }
+
+        area_ax.clear()
+        area_ax.set_facecolor(PANEL)
+        area_ax.stackplot(current_x, current_matrix, colors=colors, alpha=0.94, linewidth=0.0)
+        min_generation = float(sampled_generations.min())
+        max_generation = float(sampled_generations.max())
+        if math.isclose(min_generation, max_generation):
+            min_generation -= 0.5
+            max_generation += 0.5
+        area_ax.set_xlim(min_generation, max_generation)
+        area_ax.set_ylim(0.0, cumulative_max * 1.03)
+        area_ax.set_title("Clone growth over time", color=TEXT, fontsize=18, loc="left", pad=10)
+        area_ax.set_xlabel("Generation", color=SECONDARY_TEXT)
+        area_ax.set_ylabel("Cells", color=SECONDARY_TEXT)
+        area_ax.tick_params(colors=SECONDARY_TEXT, labelsize=9)
+        area_ax.grid(True, color=GRID, linewidth=0.8, alpha=0.65)
+        for spine in area_ax.spines.values():
+            spine.set_color(GRID)
+        area_ax.axvline(current_generation, color="#ffffff", alpha=0.28, linewidth=1.4)
+
+        if current_counts:
+            dominant_signature = max(current_counts, key=current_counts.get)
+            dominant_value = current_counts[dominant_signature]
+            if dominant_value > 0.0:
+                area_ax.text(
+                    0.02,
+                    0.96,
+                    f"Leading clone: {metadata_df.set_index('CloneSignature').loc[dominant_signature, 'CloneLabel']}",
+                    color=metadata_df.set_index("CloneSignature").loc[dominant_signature, "CloneColorHex"],
+                    fontsize=11,
+                    fontweight="bold",
+                    transform=area_ax.transAxes,
+                    va="top",
+                )
+
+        draw_tree_panel(tree_ax, metadata_df, positions, edges, current_generation, current_counts)
+        draw_stats_panel(stats_ax, current_generation, current_counts, metadata_df)
+
+    animation_obj = animation.FuncAnimation(
+        fig,
+        draw_frame,
+        frames=len(sampled_generations),
+        interval=max(1, int(1000 / max(fps, 1))),
+        repeat=False,
+    )
+
+    writer, actual_output = prepare_writer(output_path, fps)
+    animation_obj.save(actual_output, writer=writer, dpi=dpi)
+    plt.close(fig)
+    return actual_output
+
+
+def main() -> None:
+    args = parse_args()
+    run_dir = Path(args.input).expanduser().resolve()
+    if not run_dir.exists():
+        raise SystemExit(f"Input directory does not exist: {run_dir}")
+
+    output_path = Path(args.output).expanduser().resolve() if args.output else default_output_path(run_dir)
+    actual_output = render_clone_growth_animation(
+        run_dir=run_dir,
+        output_path=output_path,
+        fps=args.fps,
+        dpi=args.dpi,
+        max_clones=args.max_clones,
+        max_frames=args.max_frames,
+    )
+    print(f"Saved 2D clone growth animation to: {actual_output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/CellEvoX/scripts/snapshot_io.py
+++ b/CellEvoX/scripts/snapshot_io.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import colorsys
+import hashlib
+import json
+import math
+import re
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence, Set, Tuple
+
+import pandas as pd
+
+
+ANCESTOR_SIGNATURE = "ancestor"
+SNAPSHOT_MAGIC = b"CELXPOP1"
+SNAPSHOT_VERSION = 2
+
+_POPULATION_CSV_RE = re.compile(r"population_generation_(\d+)\.csv$")
+_POPULATION_BIN_RE = re.compile(r"population_generation_(\d+)\.bin$")
+_MUTATION_RE = re.compile(r"\((\d+),(\d+)\)")
+
+_HEADER_STRUCT = struct.Struct("<8sIIdIIBBB13x")
+_RECORD_STRUCT = struct.Struct("<IIffffHHIB3x")
+_DRIVER_MUTATION_STRUCT = struct.Struct("<IB")
+
+
+@dataclass(frozen=True)
+class PopulationFrameSource:
+    generation: int
+    path: Path
+    kind: str
+
+
+@dataclass(frozen=True)
+class SnapshotFrame:
+    generation: int
+    tau: float
+    spatial_dimensions: int
+    data: pd.DataFrame
+
+
+def resolve_run_dir(input_dir: str | Path) -> Path:
+    return Path(input_dir).expanduser().resolve()
+
+
+def load_config(run_dir: str | Path) -> Dict:
+    run_path = resolve_run_dir(run_dir)
+    candidate_paths = [run_path / "config.json", run_path.parent / "config.json"]
+    for config_path in candidate_paths:
+        if config_path.exists():
+            with config_path.open("r", encoding="utf-8") as handle:
+                return json.load(handle)
+    raise FileNotFoundError(f"config.json not found for run directory: {run_path}")
+
+
+def load_driver_type_ids(run_dir: str | Path) -> Set[int]:
+    config = load_config(run_dir)
+    driver_ids: Set[int] = set()
+    for mutation in config.get("mutations", []):
+        if mutation.get("is_driver", False):
+            driver_ids.add(int(mutation.get("id")))
+    return driver_ids
+
+
+def load_statistics(run_dir: str | Path) -> Optional[pd.DataFrame]:
+    run_path = resolve_run_dir(run_dir)
+    stats_path = run_path / "statistics" / "generational_statistics.csv"
+    if not stats_path.exists():
+        return None
+    stats = pd.read_csv(stats_path)
+    if "Generation" in stats.columns:
+        stats = stats.sort_values("Generation").reset_index(drop=True)
+    return stats
+
+
+def load_phylogeny(run_dir: str | Path) -> Optional[pd.DataFrame]:
+    run_path = resolve_run_dir(run_dir)
+    phylogeny_path = run_path / "phylogeny" / "phylogenetic_tree.csv"
+    if not phylogeny_path.exists():
+        return None
+    phylogeny = pd.read_csv(phylogeny_path)
+    if "NodeID" in phylogeny.columns:
+        phylogeny = phylogeny.sort_values("NodeID").reset_index(drop=True)
+    return phylogeny
+
+
+def phylogeny_death_times(phylogeny: Optional[pd.DataFrame]) -> Dict[int, float]:
+    if phylogeny is None or phylogeny.empty:
+        return {}
+    node_ids = phylogeny.get("NodeID")
+    death_times = phylogeny.get("DeathTime")
+    if node_ids is None or death_times is None:
+        return {}
+    return {
+        int(node_id): float(death_time)
+        for node_id, death_time in zip(node_ids.tolist(), death_times.tolist())
+    }
+
+
+def parse_mutations(mutations_str: object) -> List[Tuple[int, int]]:
+    if mutations_str is None or mutations_str == "" or mutations_str == '""' or pd.isna(mutations_str):
+        return []
+    mutations: List[Tuple[int, int]] = []
+    for match in _MUTATION_RE.finditer(str(mutations_str).strip('"')):
+        mutations.append((int(match.group(1)), int(match.group(2))))
+    return mutations
+
+
+def signature_to_driver_ids(signature: str) -> Tuple[int, ...]:
+    if not signature or signature == ANCESTOR_SIGNATURE:
+        return ()
+    return tuple(int(part) for part in signature.split(","))
+
+
+def driver_signature_from_mutations(
+    mutations: Sequence[Tuple[int, int]], driver_type_ids: Set[int]
+) -> str:
+    driver_ids = [mutation_id for mutation_id, mutation_type in mutations if mutation_type in driver_type_ids]
+    return driver_signature_from_driver_ids(driver_ids)
+
+
+def driver_signature_from_driver_ids(driver_ids: Iterable[int]) -> str:
+    normalized = sorted({int(driver_id) for driver_id in driver_ids})
+    if not normalized:
+        return ANCESTOR_SIGNATURE
+    return ",".join(str(driver_id) for driver_id in normalized)
+
+
+def find_parent_signature(signature: str, all_signatures: Iterable[str]) -> str:
+    signature_set = set(all_signatures)
+    if signature == ANCESTOR_SIGNATURE:
+        return ""
+
+    parts = list(signature_to_driver_ids(signature))
+    for index in range(len(parts)):
+        candidate_parts = parts[:index] + parts[index + 1 :]
+        candidate = driver_signature_from_driver_ids(candidate_parts)
+        if candidate in signature_set:
+            return candidate
+
+    return ANCESTOR_SIGNATURE
+
+
+def signature_depth(signature: str) -> int:
+    return len(signature_to_driver_ids(signature))
+
+
+def clone_label(signature: str) -> str:
+    if signature == ANCESTOR_SIGNATURE:
+        return "ancestor"
+    return f"clone {signature}"
+
+
+def clone_rgb(signature: str, alpha: float = 1.0) -> Tuple[float, float, float, float]:
+    if signature == ANCESTOR_SIGNATURE:
+        return (0.62, 0.62, 0.62, alpha)
+
+    digest = hashlib.sha1(signature.encode("utf-8")).digest()
+    hue = int.from_bytes(digest[:2], "big") / 65535.0
+    saturation = 0.65 + (digest[2] / 255.0) * 0.20
+    value = 0.82 + (digest[3] / 255.0) * 0.12
+    red, green, blue = colorsys.hsv_to_rgb(hue, saturation, value)
+    return (red, green, blue, alpha)
+
+
+def clone_hex(signature: str) -> str:
+    red, green, blue, _ = clone_rgb(signature)
+    return "#{:02x}{:02x}{:02x}".format(
+        int(red * 255),
+        int(green * 255),
+        int(blue * 255),
+    )
+
+
+def annotate_clone_columns(df: pd.DataFrame, driver_type_ids: Set[int]) -> pd.DataFrame:
+    working = df.copy()
+
+    signatures: List[str] = []
+    for mutation_entry in working.get("Mutations", pd.Series([""] * len(working))):
+        signatures.append(driver_signature_from_mutations(parse_mutations(mutation_entry), driver_type_ids))
+
+    working["CloneSignature"] = signatures
+    working["CloneLabel"] = [clone_label(signature) for signature in signatures]
+    working["IsAncestor"] = [signature == ANCESTOR_SIGNATURE for signature in signatures]
+    working["CloneColorHex"] = [clone_hex(signature) for signature in signatures]
+    return working
+
+
+def population_data_dir(run_dir: str | Path) -> Path:
+    run_path = resolve_run_dir(run_dir)
+    candidate = run_path / "population_data"
+    return candidate if candidate.exists() else run_path
+
+
+def discover_population_sources(
+    run_dir: str | Path,
+    prefer_bin: bool = False,
+) -> List[PopulationFrameSource]:
+    data_dir = population_data_dir(run_dir)
+    csv_sources: List[PopulationFrameSource] = []
+    bin_sources: List[PopulationFrameSource] = []
+
+    for path in sorted(data_dir.iterdir()):
+        if not path.is_file():
+            continue
+
+        csv_match = _POPULATION_CSV_RE.match(path.name)
+        if csv_match:
+            csv_sources.append(
+                PopulationFrameSource(generation=int(csv_match.group(1)), path=path, kind="csv")
+            )
+            continue
+
+        bin_match = _POPULATION_BIN_RE.match(path.name)
+        if bin_match:
+            bin_sources.append(
+                PopulationFrameSource(generation=int(bin_match.group(1)), path=path, kind="bin")
+            )
+
+    csv_sources.sort(key=lambda item: item.generation)
+    bin_sources.sort(key=lambda item: item.generation)
+
+    if prefer_bin and bin_sources:
+        return bin_sources
+    if csv_sources:
+        return csv_sources
+    if bin_sources:
+        return bin_sources
+    return []
+
+
+def load_population_frame(
+    source: PopulationFrameSource,
+    driver_type_ids: Set[int],
+) -> SnapshotFrame:
+    if source.kind == "csv":
+        return _load_population_csv(source, driver_type_ids)
+    if source.kind == "bin":
+        return _load_population_bin(source)
+    raise ValueError(f"Unsupported population source kind: {source.kind}")
+
+
+def iter_population_frames(
+    run_dir: str | Path,
+    driver_type_ids: Optional[Set[int]] = None,
+    prefer_bin: bool = False,
+) -> Iterator[SnapshotFrame]:
+    resolved_driver_ids = driver_type_ids if driver_type_ids is not None else load_driver_type_ids(run_dir)
+    for source in discover_population_sources(run_dir, prefer_bin=prefer_bin):
+        yield load_population_frame(source, resolved_driver_ids)
+
+
+def load_population_frames(
+    run_dir: str | Path,
+    driver_type_ids: Optional[Set[int]] = None,
+    prefer_bin: bool = False,
+) -> List[SnapshotFrame]:
+    return list(iter_population_frames(run_dir, driver_type_ids=driver_type_ids, prefer_bin=prefer_bin))
+
+
+def build_clone_timecourse(
+    run_dir: str | Path,
+    prefer_bin: bool = False,
+) -> Tuple[pd.DataFrame, pd.DataFrame, Optional[pd.DataFrame], Optional[pd.DataFrame]]:
+    driver_type_ids = load_driver_type_ids(run_dir)
+    counts_rows: List[pd.Series] = []
+    generations: List[int] = []
+
+    for frame in iter_population_frames(run_dir, driver_type_ids=driver_type_ids, prefer_bin=prefer_bin):
+        counts = frame.data["CloneSignature"].value_counts().sort_index()
+        counts_rows.append(counts)
+        generations.append(frame.generation)
+
+    if not counts_rows:
+        raise ValueError(f"No population snapshots found for run: {resolve_run_dir(run_dir)}")
+
+    counts_df = pd.DataFrame(counts_rows, index=generations).fillna(0.0).sort_index()
+    counts_df.index.name = "Generation"
+    counts_df = counts_df.astype(float)
+
+    phylogeny = load_phylogeny(run_dir)
+    stats = load_statistics(run_dir)
+    metadata = build_clone_metadata(counts_df, phylogeny)
+    return counts_df, metadata, phylogeny, stats
+
+
+def build_clone_metadata(
+    counts_df: pd.DataFrame,
+    phylogeny: Optional[pd.DataFrame] = None,
+) -> pd.DataFrame:
+    death_times = phylogeny_death_times(phylogeny)
+    all_signatures = set(str(column) for column in counts_df.columns)
+    metadata_rows: List[Dict] = []
+
+    for signature in all_signatures:
+        series = counts_df[signature]
+        active_generations = series[series > 0]
+        if active_generations.empty:
+            first_generation = math.nan
+            last_generation = math.nan
+        else:
+            first_generation = float(active_generations.index.min())
+            last_generation = float(active_generations.index.max())
+
+        driver_ids = signature_to_driver_ids(signature)
+        added_driver_id = driver_ids[-1] if driver_ids else None
+        metadata_rows.append(
+            {
+                "CloneSignature": signature,
+                "ParentSignature": find_parent_signature(signature, all_signatures),
+                "CloneDepth": signature_depth(signature),
+                "FirstGeneration": first_generation,
+                "LastGeneration": last_generation,
+                "PeakCells": float(series.max()),
+                "TotalCells": float(series.sum()),
+                "BirthTime": max((death_times.get(driver_id, 0.0) for driver_id in driver_ids), default=0.0),
+                "AddedDriverId": added_driver_id,
+                "CloneLabel": clone_label(signature),
+                "CloneColorHex": clone_hex(signature),
+                "IsAncestor": signature == ANCESTOR_SIGNATURE,
+            }
+        )
+
+    metadata = pd.DataFrame(metadata_rows)
+    return metadata.sort_values(
+        by=["IsAncestor", "CloneDepth", "PeakCells", "CloneSignature"],
+        ascending=[False, True, False, True],
+    ).reset_index(drop=True)
+
+
+def pick_top_clones(
+    counts_df: pd.DataFrame,
+    metadata_df: pd.DataFrame,
+    max_clones: int,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    if max_clones <= 0 or len(counts_df.columns) <= max_clones:
+        return counts_df.copy(), metadata_df.copy()
+
+    metadata = metadata_df.copy()
+    keep_signatures = metadata.sort_values(
+        by=["IsAncestor", "PeakCells", "TotalCells"],
+        ascending=[False, False, False],
+    )["CloneSignature"].head(max_clones).tolist()
+
+    for signature in list(keep_signatures):
+        current = signature
+        while current and current != ANCESTOR_SIGNATURE:
+            parent = metadata.loc[metadata["CloneSignature"] == current, "ParentSignature"]
+            if parent.empty:
+                break
+            current = str(parent.iloc[0])
+            if current and current not in keep_signatures:
+                keep_signatures.append(current)
+
+    keep_signatures = sorted(set(keep_signatures), key=lambda item: (signature_depth(item), item))
+    reduced = counts_df.reindex(columns=keep_signatures, fill_value=0.0).copy()
+    hidden_columns = [column for column in counts_df.columns if column not in keep_signatures]
+    if hidden_columns:
+        reduced["other"] = counts_df[hidden_columns].sum(axis=1)
+
+    reduced_metadata = metadata[metadata["CloneSignature"].isin(keep_signatures)].copy()
+    if hidden_columns:
+        other_row = {
+            "CloneSignature": "other",
+            "ParentSignature": ANCESTOR_SIGNATURE,
+            "CloneDepth": 1,
+            "FirstGeneration": float(reduced.index.min()),
+            "LastGeneration": float(reduced.index.max()),
+            "PeakCells": float(reduced["other"].max()),
+            "TotalCells": float(reduced["other"].sum()),
+            "BirthTime": 0.0,
+            "AddedDriverId": None,
+            "CloneLabel": "other clones",
+            "CloneColorHex": "#3f4650",
+            "IsAncestor": False,
+        }
+        reduced_metadata.loc[len(reduced_metadata)] = other_row
+
+    return reduced, reduced_metadata.reset_index(drop=True)
+
+
+def _load_population_csv(source: PopulationFrameSource, driver_type_ids: Set[int]) -> SnapshotFrame:
+    df = pd.read_csv(source.path)
+    if "PositionValid" not in df.columns:
+        df["PositionValid"] = 0
+    if "SpatialDimensions" not in df.columns:
+        spatial_dimensions = 3 if {"X", "Y", "Z"}.issubset(df.columns) else 0
+        df["SpatialDimensions"] = spatial_dimensions
+
+    annotated = annotate_clone_columns(df, driver_type_ids)
+    spatial_dimensions = int(annotated["SpatialDimensions"].iloc[0]) if not annotated.empty else 0
+    return SnapshotFrame(
+        generation=source.generation,
+        tau=float(source.generation),
+        spatial_dimensions=spatial_dimensions,
+        data=annotated,
+    )
+
+
+def _load_population_bin(source: PopulationFrameSource) -> SnapshotFrame:
+    with source.path.open("rb") as handle:
+        header_bytes = handle.read(_HEADER_STRUCT.size)
+        if len(header_bytes) != _HEADER_STRUCT.size:
+            raise ValueError(f"Incomplete snapshot header: {source.path}")
+
+        magic, version, record_size, tau, record_count, driver_mutation_count, spatial_dimensions, mutation_record_size, flags = _HEADER_STRUCT.unpack(
+            header_bytes
+        )
+
+        if magic != SNAPSHOT_MAGIC:
+            raise ValueError(f"Invalid snapshot magic in {source.path}")
+        if version != SNAPSHOT_VERSION:
+            raise ValueError(f"Unsupported snapshot version {version} in {source.path}")
+        if record_size != _RECORD_STRUCT.size:
+            raise ValueError(f"Unexpected record size {record_size} in {source.path}")
+        if mutation_record_size != _DRIVER_MUTATION_STRUCT.size:
+            raise ValueError(f"Unexpected mutation record size {mutation_record_size} in {source.path}")
+
+        records = [_RECORD_STRUCT.unpack(handle.read(_RECORD_STRUCT.size)) for _ in range(record_count)]
+        driver_mutations = [
+            _DRIVER_MUTATION_STRUCT.unpack(handle.read(_DRIVER_MUTATION_STRUCT.size))
+            for _ in range(driver_mutation_count)
+        ]
+
+    rows: List[Dict] = []
+    has_driver_payload = bool(flags & 0x1) and driver_mutation_count > 0
+
+    for (
+        cell_id,
+        parent_id,
+        fitness,
+        x_coord,
+        y_coord,
+        z_coord,
+        mutation_count,
+        driver_count,
+        driver_offset,
+        position_valid,
+    ) in records:
+        driver_slice = driver_mutations[driver_offset : driver_offset + driver_count] if has_driver_payload else []
+        driver_ids = [mutation_id for mutation_id, _ in driver_slice]
+        mutations_str = " ".join(f"({mutation_id},{mutation_type})" for mutation_id, mutation_type in driver_slice)
+        signature = driver_signature_from_driver_ids(driver_ids)
+        rows.append(
+            {
+                "CellID": cell_id,
+                "ParentID": parent_id,
+                "Fitness": fitness,
+                "MutationCount": mutation_count,
+                "Mutations": mutations_str,
+                "X": x_coord if position_valid else math.nan,
+                "Y": y_coord if position_valid else math.nan,
+                "Z": z_coord if position_valid else math.nan,
+                "PositionValid": int(position_valid),
+                "SpatialDimensions": spatial_dimensions,
+                "CloneSignature": signature,
+                "CloneLabel": clone_label(signature),
+                "IsAncestor": signature == ANCESTOR_SIGNATURE,
+                "CloneColorHex": clone_hex(signature),
+            }
+        )
+
+    frame_df = pd.DataFrame(rows)
+    return SnapshotFrame(
+        generation=source.generation,
+        tau=float(tau),
+        spatial_dimensions=int(spatial_dimensions),
+        data=frame_df,
+    )

--- a/CellEvoX/scripts/visualize_tumor_3d.py
+++ b/CellEvoX/scripts/visualize_tumor_3d.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.animation as animation
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.colors import to_rgba_array
+
+from snapshot_io import PopulationFrameSource, discover_population_sources, load_driver_type_ids, load_population_frame
+
+
+BACKGROUND = "#090b10"
+TEXT = "#f1f4f8"
+SECONDARY_TEXT = "#aeb6c2"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render a 3D tumor replay from CellEvoX snapshots.")
+    parser.add_argument("--input", required=True, help="Path to a simulation output directory")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output movie path (default: <input>/visualizations/tumor_growth_3d.mp4)",
+    )
+    parser.add_argument("--fps", type=int, default=6, help="Animation frame rate")
+    parser.add_argument("--dpi", type=int, default=160, help="Output DPI")
+    parser.add_argument(
+        "--max-frames",
+        type=int,
+        default=140,
+        help="Maximum number of snapshot checkpoints to include in the replay",
+    )
+    parser.add_argument(
+        "--max-points",
+        type=int,
+        default=80000,
+        help="Downsample large populations to at most this many cells per rendered frame",
+    )
+    parser.add_argument(
+        "--pulse-frames",
+        type=int,
+        default=12,
+        help="How many micro-frames to render per checkpoint for a slower breathing effect",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["auto", "matplotlib", "pyvista"],
+        default="auto",
+        help="Preferred renderer backend. Auto tries PyVista first and falls back to Matplotlib.",
+    )
+    parser.add_argument("--point-size", type=float, default=5.0, help="Base point size for rendered cells")
+    return parser.parse_args()
+
+
+def default_output_path(run_dir: Path) -> Path:
+    return run_dir / "visualizations" / "tumor_growth_3d.mp4"
+
+
+def prepare_writer(output_path: Path, fps: int) -> Tuple[animation.AbstractMovieWriter, Path]:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    suffix = output_path.suffix.lower()
+    if suffix == ".gif":
+        return animation.PillowWriter(fps=fps), output_path
+
+    if animation.writers.is_available("ffmpeg"):
+        return animation.FFMpegWriter(
+            fps=fps,
+            metadata={"title": "CellEvoX tumor 3D replay"},
+            codec="libx264",
+            bitrate=3200,
+        ), output_path
+
+    fallback = output_path.with_suffix(".gif")
+    print(f"Warning: ffmpeg not available, saving GIF instead: {fallback}")
+    return animation.PillowWriter(fps=max(1, min(fps, 16))), fallback
+
+
+def pick_sources(run_dir: Path, max_frames: int) -> List:
+    sources = discover_population_sources(run_dir, prefer_bin=True)
+    if not sources:
+        raise ValueError(f"No population snapshots found in {run_dir}")
+    if len(sources) <= max_frames:
+        return sources
+
+    indices = np.linspace(0, len(sources) - 1, num=max_frames, dtype=int)
+    deduplicated = []
+    seen = set()
+    for index in indices.tolist():
+        if index not in seen:
+            deduplicated.append(sources[index])
+            seen.add(index)
+    return deduplicated
+
+
+def downsample_frame(df, max_points: int):
+    if len(df) <= max_points:
+        return df
+    ordered = df.sort_values("CellID").reset_index(drop=True)
+    stride = max(1, int(math.ceil(len(ordered) / max_points)))
+    return ordered.iloc[::stride].head(max_points).reset_index(drop=True)
+
+
+def load_spatial_frames(run_dir: Path, max_frames: int, max_points: int) -> List[Dict]:
+    driver_type_ids = load_driver_type_ids(run_dir)
+    frames: List[Dict] = []
+
+    for source in pick_sources(run_dir, max_frames=max_frames):
+        try:
+            frame = load_population_frame(source, driver_type_ids)
+        except ValueError as exc:
+            if source.kind != "bin":
+                raise
+            csv_path = source.path.with_suffix(".csv")
+            if not csv_path.exists():
+                raise
+            print(f"Warning: falling back to CSV for {source.path.name} ({exc})")
+            frame = load_population_frame(
+                PopulationFrameSource(generation=source.generation, path=csv_path, kind="csv"),
+                driver_type_ids,
+            )
+        if int(frame.spatial_dimensions) != 3:
+            continue
+
+        df = frame.data.copy()
+        if "PositionValid" in df.columns:
+            df = df[df["PositionValid"].astype(int) == 1]
+        if df.empty:
+            continue
+
+        df = df.dropna(subset=["X", "Y", "Z"]).reset_index(drop=True)
+        if df.empty:
+            continue
+
+        df = downsample_frame(df, max_points=max_points)
+        points = df[["X", "Y", "Z"]].to_numpy(dtype=float)
+        colors = to_rgba_array(df["CloneColorHex"].tolist(), alpha=0.88)
+
+        frames.append(
+            {
+                "generation": float(frame.generation),
+                "tau": float(frame.tau),
+                "points": points,
+                "colors": colors,
+                "cell_count": int(len(df)),
+                "active_clones": int(df["CloneSignature"].nunique()),
+            }
+        )
+
+    if not frames:
+        raise ValueError("No spatial 3D checkpoints with valid positions were found.")
+    return frames
+
+
+def compute_bounds(frames: List[Dict]) -> Tuple[np.ndarray, float]:
+    all_points = np.vstack([frame["points"] for frame in frames if len(frame["points"]) > 0])
+    mins = all_points.min(axis=0)
+    maxs = all_points.max(axis=0)
+    center = (mins + maxs) / 2.0
+    radius = float(np.max(maxs - mins) / 2.0)
+    radius = max(radius, 1.0)
+    return center, radius
+
+
+def render_with_matplotlib(
+    frames: List[Dict],
+    output_path: Path,
+    fps: int,
+    dpi: int,
+    point_size: float,
+    pulse_frames: int,
+) -> Path:
+    center, radius = compute_bounds(frames)
+    fig = plt.figure(figsize=(11.5, 9.0), facecolor=BACKGROUND)
+    ax = fig.add_subplot(111, projection="3d")
+
+    x_limits = (center[0] - radius, center[0] + radius)
+    y_limits = (center[1] - radius, center[1] + radius)
+    z_limits = (center[2] - radius, center[2] + radius)
+    total_movie_frames = len(frames) * max(1, pulse_frames)
+
+    def draw_frame(movie_frame_index: int) -> None:
+        source_index = min(len(frames) - 1, movie_frame_index // max(1, pulse_frames))
+        pulse_phase = (movie_frame_index % max(1, pulse_frames)) / max(1, pulse_frames)
+        pulse_scale = 1.0 + 0.18 * math.sin(pulse_phase * 2.0 * math.pi)
+        frame = frames[source_index]
+
+        ax.clear()
+        ax.set_facecolor(BACKGROUND)
+        ax.scatter(
+            frame["points"][:, 0],
+            frame["points"][:, 1],
+            frame["points"][:, 2],
+            c=frame["colors"],
+            s=point_size * pulse_scale,
+            linewidths=0.0,
+            depthshade=False,
+        )
+        ax.set_xlim(*x_limits)
+        ax.set_ylim(*y_limits)
+        ax.set_zlim(*z_limits)
+        ax.set_box_aspect((1.0, 1.0, 1.0))
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.set_zticks([])
+
+        for axis in (ax.xaxis, ax.yaxis, ax.zaxis):
+            axis.pane.fill = False
+            axis.pane.set_edgecolor(BACKGROUND)
+            axis.line.set_color(BACKGROUND)
+
+        orbit_fraction = movie_frame_index / max(1, total_movie_frames - 1)
+        ax.view_init(
+            elev=19.0 + 4.0 * math.sin(orbit_fraction * 2.0 * math.pi),
+            azim=26.0 + orbit_fraction * 52.0,
+        )
+        ax.text2D(
+            0.03,
+            0.95,
+            f"3D tumor replay | generation {frame['generation']:.1f}",
+            transform=ax.transAxes,
+            color=TEXT,
+            fontsize=15,
+            fontweight="bold",
+        )
+        ax.text2D(
+            0.03,
+            0.90,
+            f"cells {frame['cell_count']:,} | active clones {frame['active_clones']}",
+            transform=ax.transAxes,
+            color=SECONDARY_TEXT,
+            fontsize=11,
+        )
+        ax.text2D(
+            0.03,
+            0.05,
+            "gray = ancestor / no drivers | colors = driver-defined clones",
+            transform=ax.transAxes,
+            color=SECONDARY_TEXT,
+            fontsize=10,
+        )
+
+    animation_obj = animation.FuncAnimation(
+        fig,
+        draw_frame,
+        frames=total_movie_frames,
+        interval=max(1, int(1000 / max(fps, 1))),
+        repeat=False,
+    )
+    writer, actual_output = prepare_writer(output_path, fps)
+    animation_obj.save(actual_output, writer=writer, dpi=dpi)
+    plt.close(fig)
+    return actual_output
+
+
+def render_with_pyvista(
+    frames: List[Dict],
+    output_path: Path,
+    fps: int,
+    point_size: float,
+    pulse_frames: int,
+) -> Path:
+    import pyvista as pv
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    actual_output = output_path
+    if actual_output.suffix.lower() not in {".mp4", ".gif"}:
+        actual_output = actual_output.with_suffix(".mp4")
+
+    center, radius = compute_bounds(frames)
+    distance = radius * 3.4
+    total_movie_frames = len(frames) * max(1, pulse_frames)
+    window_size = (1440, 1080)
+
+    plotter = pv.Plotter(off_screen=True, window_size=window_size)
+    plotter.set_background(BACKGROUND)
+
+    if actual_output.suffix.lower() == ".gif":
+        plotter.open_gif(str(actual_output))
+    else:
+        plotter.open_movie(str(actual_output), framerate=fps)
+
+    for movie_frame_index in range(total_movie_frames):
+        source_index = min(len(frames) - 1, movie_frame_index // max(1, pulse_frames))
+        pulse_phase = (movie_frame_index % max(1, pulse_frames)) / max(1, pulse_frames)
+        pulse_scale = 1.0 + 0.18 * math.sin(pulse_phase * 2.0 * math.pi)
+        frame = frames[source_index]
+
+        plotter.clear_actors()
+        plotter.add_points(
+            frame["points"],
+            scalars=frame["colors"][:, :3],
+            rgb=True,
+            render_points_as_spheres=True,
+            point_size=point_size * pulse_scale,
+        )
+
+        orbit_fraction = movie_frame_index / max(1, total_movie_frames - 1)
+        angle = math.radians(25.0 + orbit_fraction * 70.0)
+        camera_position = np.array(
+            [
+                center[0] + math.cos(angle) * distance,
+                center[1] + math.sin(angle) * distance,
+                center[2] + distance * 0.42,
+            ]
+        )
+        plotter.camera_position = [camera_position.tolist(), center.tolist(), [0.0, 0.0, 1.0]]
+        plotter.add_text(
+            f"generation {frame['generation']:.1f} | cells {frame['cell_count']:,} | clones {frame['active_clones']}",
+            position="upper_left",
+            font_size=14,
+            color=TEXT,
+        )
+        plotter.write_frame()
+
+    plotter.close()
+    return actual_output
+
+
+def render_tumor_replay(
+    run_dir: Path,
+    output_path: Path,
+    fps: int,
+    dpi: int,
+    max_frames: int,
+    max_points: int,
+    pulse_frames: int,
+    backend: str,
+    point_size: float,
+) -> Path:
+    frames = load_spatial_frames(run_dir, max_frames=max_frames, max_points=max_points)
+
+    if backend in {"auto", "pyvista"}:
+        try:
+            return render_with_pyvista(
+                frames=frames,
+                output_path=output_path,
+                fps=fps,
+                point_size=point_size,
+                pulse_frames=pulse_frames,
+            )
+        except Exception as exc:
+            if backend == "pyvista":
+                raise
+            print(f"Warning: PyVista renderer unavailable, falling back to Matplotlib ({exc})")
+
+    return render_with_matplotlib(
+        frames=frames,
+        output_path=output_path,
+        fps=fps,
+        dpi=dpi,
+        point_size=point_size,
+        pulse_frames=pulse_frames,
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    run_dir = Path(args.input).expanduser().resolve()
+    if not run_dir.exists():
+        raise SystemExit(f"Input directory does not exist: {run_dir}")
+
+    output_path = Path(args.output).expanduser().resolve() if args.output else default_output_path(run_dir)
+    try:
+        actual_output = render_tumor_replay(
+            run_dir=run_dir,
+            output_path=output_path,
+            fps=args.fps,
+            dpi=args.dpi,
+            max_frames=args.max_frames,
+            max_points=args.max_points,
+            pulse_frames=max(1, args.pulse_frames),
+            backend=args.backend,
+            point_size=max(0.1, args.point_size),
+        )
+    except ValueError as exc:
+        print(f"Skipping 3D replay: {exc}")
+        return
+
+    print(f"Saved 3D tumor replay to: {actual_output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/CellEvoX/src/core/RunDataEngine.cpp
+++ b/CellEvoX/src/core/RunDataEngine.cpp
@@ -146,6 +146,35 @@ std::vector<fs::path> collectPopulationBinaryFiles(const std::string& output_dir
   return files;
 }
 
+std::string quoteForShell(const std::string& value) { return "\"" + value + "\""; }
+
+fs::path resolvePythonScriptPath(const char* script_name) {
+  fs::path script_path = fs::current_path() / "scripts" / script_name;
+  if (fs::exists(script_path)) {
+    return script_path;
+  }
+
+  script_path = fs::path(__FILE__).parent_path().parent_path() / "scripts" / script_name;
+  if (fs::exists(script_path)) {
+    return script_path;
+  }
+
+  script_path = fs::path("/workspaces/CellEvoX/CellEvoX/scripts") / script_name;
+  if (fs::exists(script_path)) {
+    return script_path;
+  }
+
+  return fs::current_path() / "../scripts" / script_name;
+}
+
+std::string resolvePythonCommand() {
+  fs::path venv_python = "/workspaces/CellEvoX/.venv/bin/python";
+  if (fs::exists(venv_python)) {
+    return venv_python.string();
+  }
+  return "python3";
+}
+
 }  // namespace
 
 namespace CellEvoX::core {
@@ -889,6 +918,57 @@ void RunDataEngine::plotCloneLifespans() {
     spdlog::info("Clone lifespans charts saved to clones/ subdirectory.");
   } else {
     spdlog::warn("Clone lifespans chart generation failed with code: {}", result);
+  }
+}
+
+void RunDataEngine::plotCloneGrowthAnimation() {
+  spdlog::info("Generating animated 2D clone growth visualization...");
+
+  std::filesystem::path script_path = resolvePythonScriptPath("animate_clone_growth_2d.py");
+  if (!std::filesystem::exists(script_path)) {
+    spdlog::warn("2D clone growth script not found at any locations, last tried: {}",
+                 script_path.string());
+    return;
+  }
+
+  const std::string python_cmd = resolvePythonCommand();
+  const std::string command =
+      python_cmd + " " + quoteForShell(script_path.string()) + " --input " +
+      quoteForShell(output_dir) + " --output " +
+      quoteForShell(output_dir + "visualizations/clone_growth_2d.mp4");
+
+  spdlog::info("Running 2D clone growth animation: {}", command);
+  const int result = std::system(command.c_str());
+  if (result == 0) {
+    spdlog::info("2D clone growth animation saved to: {}visualizations/clone_growth_2d.mp4",
+                 output_dir);
+  } else {
+    spdlog::warn("2D clone growth animation failed with code: {}", result);
+  }
+}
+
+void RunDataEngine::plotTumorReplay3D() {
+  spdlog::info("Generating 3D tumor replay...");
+
+  std::filesystem::path script_path = resolvePythonScriptPath("visualize_tumor_3d.py");
+  if (!std::filesystem::exists(script_path)) {
+    spdlog::warn("3D tumor replay script not found at any locations, last tried: {}",
+                 script_path.string());
+    return;
+  }
+
+  const std::string python_cmd = resolvePythonCommand();
+  const std::string command =
+      python_cmd + " " + quoteForShell(script_path.string()) + " --input " +
+      quoteForShell(output_dir) + " --output " +
+      quoteForShell(output_dir + "visualizations/tumor_growth_3d.mp4");
+
+  spdlog::info("Running 3D tumor replay: {}", command);
+  const int result = std::system(command.c_str());
+  if (result == 0) {
+    spdlog::info("3D tumor replay saved to: {}visualizations/tumor_growth_3d.mp4", output_dir);
+  } else {
+    spdlog::warn("3D tumor replay failed with code: {}", result);
   }
 }
 

--- a/CellEvoX/src/core/application.cpp
+++ b/CellEvoX/src/core/application.cpp
@@ -52,6 +52,8 @@ void Application::initialize() {
       data_engine.plotClonePhylogenyTree();
       data_engine.plotCloneCounts();
       data_engine.plotCloneLifespans();
+      data_engine.plotCloneGrowthAnimation();
+      data_engine.plotTumorReplay3D();
     } else if (has_population_bin) {
       data_engine.exportPopulationSnapshotsToCSV();
       spdlog::info(
@@ -60,6 +62,8 @@ void Application::initialize() {
       data_engine.plotClonePhylogenyTree();
       data_engine.plotCloneCounts();
       data_engine.plotCloneLifespans();
+      data_engine.plotCloneGrowthAnimation();
+      data_engine.plotTumorReplay3D();
     }
     
     spdlog::info("Analysis complete.");
@@ -105,6 +109,8 @@ void Application::initialize() {
     data_engine.plotClonePhylogenyTree();
     data_engine.plotCloneCounts();
     data_engine.plotCloneLifespans();
+    data_engine.plotCloneGrowthAnimation();
+    data_engine.plotTumorReplay3D();
   } else {
     spdlog::error("Neither --config nor --analyze flag was provided. Please provide one.");
   }

--- a/CellEvoX/src/systems/SimulationEngine.cpp
+++ b/CellEvoX/src/systems/SimulationEngine.cpp
@@ -61,7 +61,9 @@ SimulationEngine::SimulationEngine(std::shared_ptr<SimulationConfig> config)
 
   // These are informational logs; they will be filtered by spdlog's level.
   spdlog::info("=== Simulation Engine Initialized ===");
-  spdlog::info("Initial population: {}, Capacity: {}", config->initial_population, config->env_capacity);
+  spdlog::info("Initial population: {}, Well-mixed carrying capacity: {}",
+               config->initial_population,
+               config->env_capacity);
   spdlog::info("Tau step: {}, Total mutation probability: {:.6f}", config->tau_step, total_mutation_probability);
 
   // Initialize memory logging
@@ -174,9 +176,17 @@ void SimulationEngine::stochasticStep() {
   }
   std::sort(alive_cell_indices.begin(), alive_cell_indices.end());
 
+  const Eigen::VectorXd fitnesses =
+      FitnessCalculator::getCellsFitnessVector(cells, alive_cell_indices);
+  const double mean_fitness =
+      std::max(fitnesses.mean(), std::numeric_limits<double>::epsilon());
+  // In the well-mixed model, fitness should express relative clonal advantage.
+  // Normalizing by the population mean keeps env_capacity as the population-scale
+  // carrying capacity instead of letting mean fitness inflate total size.
+  const Eigen::ArrayXd effective_birth_rates =
+      (fitnesses.array() / mean_fitness).max(std::numeric_limits<double>::epsilon());
   Eigen::VectorXd birth_probs =
-      generateExponentialDistribution(N, rng).array() /
-      FitnessCalculator::getCellsFitnessVector(cells, alive_cell_indices).array();
+      generateExponentialDistribution(N, rng).array() / effective_birth_rates;
 
   if (alive_cell_indices.size() != N) {
     spdlog::error(

--- a/CellEvoX/tests/benchmarks/correctness_baseline.json
+++ b/CellEvoX/tests/benchmarks/correctness_baseline.json
@@ -12,39 +12,39 @@
     "total_living_cells": 206
   },
   {
-    "fitness_kurtosis": 2.7959076049910436e-05,
-    "fitness_skewness": 0.00017611037530995688,
-    "fitness_variance": 0.0014690971876691883,
-    "mean_fitness": 1.0129556679373304,
-    "mean_mutations": 0.12807881773399016,
-    "mutations_kurtosis": 0.23863966060531305,
-    "mutations_skewness": 0.16038153222782292,
-    "mutations_variance": 0.1412312844281589,
+    "fitness_kurtosis": 1.4089077885248713e-05,
+    "fitness_skewness": 0.00010606775608223984,
+    "fitness_variance": 0.001038200699825298,
+    "mean_fitness": 1.010255104425002,
+    "mean_mutations": 0.10204081632653061,
+    "mutations_kurtosis": 0.12601241569310026,
+    "mutations_skewness": 0.10041734311383864,
+    "mutations_variance": 0.10183256976259891,
     "tau": 2.000000000000001,
-    "total_living_cells": 406
+    "total_living_cells": 392
   },
   {
-    "fitness_kurtosis": 2.76064596107517e-05,
-    "fitness_skewness": 0.00018470693572814056,
-    "fitness_variance": 0.001810023519039472,
-    "mean_fitness": 1.017709927704498,
-    "mean_mutations": 0.17557251908396945,
-    "mutations_kurtosis": 0.23694789378228728,
-    "mutations_skewness": 0.1694397602232294,
-    "mutations_variance": 0.17528116077151681,
+    "fitness_kurtosis": 3.2441674806538146e-05,
+    "fitness_skewness": 0.00018322393294534223,
+    "fitness_variance": 0.001726542047691293,
+    "mean_fitness": 1.0173490894276922,
+    "mean_mutations": 0.1722560975609756,
+    "mutations_kurtosis": 0.2548269520821134,
+    "mutations_skewness": 0.1631749986510824,
+    "mutations_variance": 0.1669741783164783,
     "tau": 3.049999999999997,
-    "total_living_cells": 655
+    "total_living_cells": 656
   },
   {
-    "fitness_kurtosis": 2.8536128568124042e-05,
-    "fitness_skewness": 0.00019355778732732531,
-    "fitness_variance": 0.002310927486841141,
-    "mean_fitness": 1.0251847348483325,
-    "mean_mutations": 0.25,
-    "mutations_kurtosis": 0.24366918103448276,
-    "mutations_skewness": 0.17687807881773396,
-    "mutations_variance": 0.22444581280788178,
+    "fitness_kurtosis": 4.723820307139803e-05,
+    "fitness_skewness": 0.00024901897624829417,
+    "fitness_variance": 0.002342778789857558,
+    "mean_fitness": 1.0233819498508065,
+    "mean_mutations": 0.23148148148148148,
+    "mutations_kurtosis": 0.36378577449095945,
+    "mutations_skewness": 0.21616528222323833,
+    "mutations_variance": 0.22419410150891633,
     "tau": 4.049999999999994,
-    "total_living_cells": 812
+    "total_living_cells": 864
   }
 ]

--- a/CellEvoX/tests/test_simulation.cpp
+++ b/CellEvoX/tests/test_simulation.cpp
@@ -293,6 +293,31 @@ inline bool snapshot_within_domain(
     });
 }
 
+inline std::shared_ptr<SimulationConfig> make_well_mixed_test_config(
+    size_t initial_population,
+    size_t env_capacity,
+    uint32_t steps,
+    const std::string& output_path
+) {
+    auto config = std::make_shared<SimulationConfig>();
+    config->sim_type = SimulationType::STOCHASTIC_TAU_LEAP;
+    config->tau_step = 0.05;
+    config->seed = 42;
+    config->initial_population = initial_population;
+    config->env_capacity = env_capacity;
+    config->steps = steps;
+    config->stat_res = 1;
+    config->popul_res = 1000;
+    config->output_path = output_path;
+    config->verbosity = 0;
+    return config;
+}
+
+inline void prepare_output_dir(const std::string& output_path) {
+    std::filesystem::remove_all(output_path);
+    std::filesystem::create_directories(std::filesystem::path(output_path) / "statistics");
+}
+
 TEST_CASE("Algorithmic Correctness Baseline", "[Correctness]") {
     auto config = std::make_shared<SimulationConfig>();
     config->sim_type = SimulationType::STOCHASTIC_TAU_LEAP;
@@ -385,6 +410,66 @@ TEST_CASE("Algorithmic Correctness Baseline", "[Correctness]") {
         require_approx(actual.mutations_skewness, expected["mutations_skewness"].get<double>());
         require_approx(actual.mutations_kurtosis, expected["mutations_kurtosis"].get<double>());
     }
+}
+
+TEST_CASE("Well-mixed 2D neutral population stabilizes near environment capacity",
+          "[SimulationEngine][Capacity]") {
+    tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+
+    auto config = make_well_mixed_test_config(100, 1000, 400, "/tmp/test_sim_capacity_neutral");
+    prepare_output_dir(config->output_path);
+
+    SimulationEngine engine(config);
+    auto runData = engine.run(config->steps);
+
+    const auto& stats = runData.generational_stat_report;
+    REQUIRE(stats.size() >= 3);
+
+    const size_t final_population = stats.back().total_living_cells;
+    REQUIRE(final_population > static_cast<size_t>(0.85 * config->env_capacity));
+    REQUIRE(final_population < static_cast<size_t>(1.15 * config->env_capacity));
+    REQUIRE(stats.back().mean_fitness == Catch::Approx(1.0).margin(1e-6));
+
+    const auto tail_begin = stats.end() - 3;
+    const auto [tail_min_it, tail_max_it] = std::minmax_element(
+        tail_begin, stats.end(), [](const StatSnapshot& lhs, const StatSnapshot& rhs) {
+            return lhs.total_living_cells < rhs.total_living_cells;
+        });
+    REQUIRE(static_cast<double>(tail_max_it->total_living_cells - tail_min_it->total_living_cells) <
+            0.15 * static_cast<double>(config->env_capacity));
+}
+
+TEST_CASE("Well-mixed 2D keeps selection relative instead of inflating total population",
+          "[SimulationEngine][Capacity]") {
+    tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+
+    auto neutral_config =
+        make_well_mixed_test_config(100, 1000, 400, "/tmp/test_sim_capacity_neutral_reference");
+    auto driver_config =
+        make_well_mixed_test_config(100, 1000, 400, "/tmp/test_sim_capacity_driver");
+    driver_config->mutations.push_back({0.1f, 0.05f, 1, true});
+
+    prepare_output_dir(neutral_config->output_path);
+    prepare_output_dir(driver_config->output_path);
+
+    SimulationEngine neutral_engine(neutral_config);
+    auto neutral_run = neutral_engine.run(neutral_config->steps);
+
+    SimulationEngine driver_engine(driver_config);
+    auto driver_run = driver_engine.run(driver_config->steps);
+
+    REQUIRE_FALSE(neutral_run.generational_stat_report.empty());
+    REQUIRE_FALSE(driver_run.generational_stat_report.empty());
+
+    const auto& neutral_final = neutral_run.generational_stat_report.back();
+    const auto& driver_final = driver_run.generational_stat_report.back();
+
+    REQUIRE(driver_final.mean_fitness > neutral_final.mean_fitness + 0.05);
+    REQUIRE(driver_final.total_living_cells > static_cast<size_t>(0.85 * driver_config->env_capacity));
+    REQUIRE(driver_final.total_living_cells < static_cast<size_t>(1.15 * driver_config->env_capacity));
+    REQUIRE(std::abs(static_cast<double>(driver_final.total_living_cells) -
+                     static_cast<double>(neutral_final.total_living_cells)) <
+            0.15 * static_cast<double>(driver_config->env_capacity));
 }
 
 TEST_CASE("SimulationEngine3D produces binary population snapshots", "[SimulationEngine3D]") {

--- a/CellEvoX/tests/test_simulation.cpp
+++ b/CellEvoX/tests/test_simulation.cpp
@@ -448,6 +448,64 @@ TEST_CASE("SimulationEngine3D grows from a sparse neutral state", "[SimulationEn
     REQUIRE(runData.generational_stat_report.back().total_living_cells > config->initial_population);
 }
 
+TEST_CASE("SimulationEngine3D deterministic smoke test", "[SimulationEngine3D][Determinism][CI]") {
+    tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+
+    auto make_config = [](const std::string& output_path) {
+        auto config = std::make_shared<SimulationConfig>();
+        config->sim_type = SimulationType::SPATIAL_3D_ABM;
+        config->tau_step = 1.0;
+        config->seed = 321;
+        config->initial_population = 16;
+        config->env_capacity = 128;
+        config->steps = 3;
+        config->stat_res = 1;
+        config->popul_res = 1;
+        config->output_path = output_path;
+        config->spatial_domain_size = 20.0f;
+        config->sample_radius = 3.0f;
+        config->max_local_density = 8.0f;
+        config->spring_constant = 0.2f;
+        config->mech_dt = 0.05f;
+        config->mech_substeps = 2;
+        config->epsilon = 0.1f;
+        config->verbosity = 0;
+        return config;
+    };
+
+    auto config1 = make_config("/tmp/test_sim_3d_smoke_1");
+    auto config2 = make_config("/tmp/test_sim_3d_smoke_2");
+
+    std::filesystem::remove_all(config1->output_path);
+    std::filesystem::remove_all(config2->output_path);
+    std::filesystem::create_directories(config1->output_path);
+    std::filesystem::create_directories(config2->output_path);
+
+    SimulationEngine3D engine1(config1);
+    auto runData1 = engine1.run(3);
+
+    SimulationEngine3D engine2(config2);
+    auto runData2 = engine2.run(3);
+
+    REQUIRE(runData1.generational_stat_report.size() == runData2.generational_stat_report.size());
+    REQUIRE(runData1.generational_stat_report.size() == 3);
+
+    for (size_t i = 0; i < runData1.generational_stat_report.size(); ++i) {
+        const auto& lhs = runData1.generational_stat_report[i];
+        const auto& rhs = runData2.generational_stat_report[i];
+        require_approx(lhs.tau, rhs.tau);
+        require_approx(lhs.mean_fitness, rhs.mean_fitness);
+        require_approx(lhs.mean_mutations, rhs.mean_mutations);
+        REQUIRE(lhs.total_living_cells == rhs.total_living_cells);
+    }
+
+    const auto snapshot1 = read_binary_file(
+        std::filesystem::path(config1->output_path) / "population_data" / "population_generation_1.bin");
+    const auto snapshot2 = read_binary_file(
+        std::filesystem::path(config2->output_path) / "population_data" / "population_generation_1.bin");
+    REQUIRE(snapshot1 == snapshot2);
+}
+
 TEST_CASE("SimulationEngine3D is repeatable with the same seed", "[SimulationEngine3D][Determinism]") {
     tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,40 @@ CellEvoX is a simulation system for modeling population dynamics, incorporating 
 2. Run the simulation executable with --config pointing to config file localization.
 3. View the generated data and statistical reports created in output directory specified in config. (Docker needs a write permission to output dir)
 
+## Post-process Visualization
+
+CellEvoX can now generate two offline visualizations from an existing run directory:
+
+- `clone_growth_2d.mp4` - an animated clone-growth view built from clone counts over time.
+- `tumor_growth_3d.mp4` - a spatial replay of the 3D tumor with clone colors.
+
+Both outputs are written under `visualizations/` inside the run directory.
+
+### Recommended Python extras
+
+The existing analysis scripts use `matplotlib`, `numpy`, `pandas`, and `networkx`. For the new 3D replay, `pyvista` is recommended but optional because the script falls back to a Matplotlib renderer when PyVista is unavailable.
+
+Example:
+
+```bash
+pip install pandas networkx pyvista
+```
+
+For MP4 export, make sure `ffmpeg` is available in the environment. If it is missing, the scripts fall back to GIF output.
+
+### Run on an existing output directory
+
+```bash
+./bin/CellEvoX --analyze /path/to/run_dir
+```
+
+### Run the visualization scripts manually
+
+```bash
+python CellEvoX/scripts/animate_clone_growth_2d.py --input /path/to/run_dir
+python CellEvoX/scripts/visualize_tumor_3d.py --input /path/to/run_dir
+```
+
 ## File Structure
 
 - **include/**: Header files defining core components.


### PR DESCRIPTION
## Summary

This changes the well-mixed 2D model so fitness acts as a **relative selective advantage**, not as a multiplier of the whole population carrying capacity.

In practice:
- well-mixed 2D birth pressure is now normalized by population mean fitness: `fitness / mean_fitness`
- death scaling remains `N / env_capacity`
- `env_capacity` is now aligned with the intuitive meaning of a population-scale carrying capacity in nonspatial 2D
- config/log wording was clarified to distinguish well-mixed `env_capacity` from spatial 3D `max_local_density`
- regression tests and the correctness baseline were updated accordingly

## Why

Before this change, the nonspatial 2D model used:
- death rate scaled by `N / env_capacity`
- birth rate scaled by absolute `fitness`

That made the effective equilibrium behave approximately like:

`N* ~= env_capacity * mean_fitness`

As fitter drivers accumulated, mean fitness increased and the whole population size drifted far above `env_capacity`. This was internally consistent with the old implementation, but it was a poor match for the name and expected meaning of `env_capacity`.

After this change, fitter clones still outcompete less-fit clones, but increasing mean fitness no longer inflates the global population ceiling.

## Before / After Experiment

I ran the same well-mixed 2D scenario on:
1. the version before the fix
2. the current version after the fix

Shared setup:
- `env_capacity = 4000`
- `initial_population = 250`
- same seed
- same driver / passenger mutation mix
- same runtime horizon (`tau ~= 190`)

### End state comparison

- **Before fix**
  - final population: `9967` (`2.49x env_capacity`)
  - final mean fitness: `2.559`
  - `N / (Nc * mean_fitness) ~= 0.974`

- **After fix**
  - final population: `3938` (`0.98x env_capacity`)
  - final mean fitness: `1.599`
  - population remains near `env_capacity` even as fitness rises

This strongly supports the original diagnosis:
- **before**: population size tracked the old model’s implicit `Nc * mean_fitness`
- **after**: fitness still increases, but carrying capacity stays tied to `env_capacity`

### Checkpoints

| Tau | Cells before | Cells after | Fitness before | Fitness after |
| --- | ---: | ---: | ---: | ---: |
| 10 | 3978 | 4033 | 1.002 | 1.001 |
| 20 | 4018 | 3967 | 1.008 | 1.009 |
| 40 | 4153 | 3934 | 1.027 | 1.035 |
| 60 | 4368 | 4015 | 1.101 | 1.101 |
| 80 | 4868 | 3833 | 1.235 | 1.160 |
| 100 | 5298 | 3919 | 1.331 | 1.231 |
| 120 | 5776 | 3991 | 1.478 | 1.311 |
| 140 | 6482 | 3918 | 1.650 | 1.372 |
| 160 | 7107 | 3838 | 1.830 | 1.449 |
| 180 | 8947 | 3967 | 2.310 | 1.538 |
| 190 | 9967 | 3938 | 2.559 | 1.599 |

## Validation

Passed:
- `./build/bin/CellEvoXTests "[SimulationEngine][Capacity]"`
- `./build/bin/CellEvoXTests "~[benchmark]"`

Also updated:
- `CellEvoX/tests/benchmarks/correctness_baseline.json`

## Comparison Artifacts

Run outputs:
- before: `/workspaces/CellEvoX/build/capacity_compare/before/2026-04-19_10-09-12`
- after: `/workspaces/CellEvoX/build/capacity_compare/after/2026-04-19_10-09-47`

Config files:
- `build/capacity_compare_before_config.json`
- `build/capacity_compare_after_config.json`

## Notes

The comparison runs generated the usual CSVs, snapshots, and 2D animations. Müller plots were not produced in this environment because `pyfish` is not installed, but that does not affect the population/fitness comparison above.