### PR TITLE
Optimize 3D capacity simulation hot paths

### DIFF
--- a/CellEvoX/CMakeLists.txt
+++ b/CellEvoX/CMakeLists.txt
@@ -92,6 +92,7 @@ set(HEADERS
     include/ecs/Run.hpp
     include/spatial/SpatialHashGrid.hpp
     include/utils/MathUtils.hpp
+    include/utils/ParallelAlgorithms.hpp
     include/utils/PhaseProfiler.hpp
     include/utils/SimulationConfig.hpp
     include/core/RunDataEngine.hpp

--- a/CellEvoX/include/spatial/SpatialHashGrid.hpp
+++ b/CellEvoX/include/spatial/SpatialHashGrid.hpp
@@ -40,12 +40,18 @@ class SpatialHashGrid {
       for (int iy = iy_min; iy <= iy_max; ++iy) {
         for (int ix = ix_min; ix <= ix_max; ++ix) {
           const int64_t hash = hashVoxel(ix, iy, iz);
-          const auto range_it = voxel_ranges_.find(hash);
-          if (range_it == voxel_ranges_.end()) {
-            continue;
+          std::pair<int32_t, int32_t> voxel_range{0, 0};
+          if (use_dense_ranges_) {
+            voxel_range = dense_voxel_ranges_[static_cast<size_t>(hash)];
+          } else {
+            const auto range_it = voxel_ranges_.find(hash);
+            if (range_it == voxel_ranges_.end()) {
+              continue;
+            }
+            voxel_range = range_it->second;
           }
 
-          const auto [begin_idx, end_idx] = range_it->second;
+          const auto [begin_idx, end_idx] = voxel_range;
           for (int32_t idx = begin_idx; idx < end_idx; ++idx) {
             cb(sorted_ids_[static_cast<size_t>(idx)]);
           }
@@ -64,5 +70,7 @@ class SpatialHashGrid {
 
   std::vector<uint32_t> sorted_ids_;
   std::vector<int32_t> cell_voxel_;
+  std::vector<std::pair<int32_t, int32_t>> dense_voxel_ranges_;
   std::unordered_map<int64_t, std::pair<int32_t, int32_t>> voxel_ranges_;
+  bool use_dense_ranges_ = false;
 };

--- a/CellEvoX/include/systems/CommonPopulationStep.hpp
+++ b/CellEvoX/include/systems/CommonPopulationStep.hpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "systems/SimulationEngine.hpp"
+#include "utils/ParallelAlgorithms.hpp"
 #include "utils/PhaseProfiler.hpp"
 
 namespace CellEvoX::systems {
@@ -93,7 +94,7 @@ inline CommonPopulationStepResult applyCommonPopulationStep(
 
   {
     CELLEVOX_PROFILE_PHASE("sort_alive_ids");
-    std::sort(alive_cell_indices.begin(), alive_cell_indices.end());
+    CellEvoX::parallel_algorithms::sortMaybeParallel(alive_cell_indices.begin(), alive_cell_indices.end());
   }
 
   if (alive_cell_indices.empty()) {
@@ -205,7 +206,8 @@ inline CommonPopulationStepResult applyCommonPopulationStep(
       sorted_new_cells.push_back(std::move(cell));
     }
 
-    std::sort(sorted_new_cells.begin(), sorted_new_cells.end(), commonDaughterCellLess);
+    CellEvoX::parallel_algorithms::sortMaybeParallel(
+        sorted_new_cells.begin(), sorted_new_cells.end(), commonDaughterCellLess);
   }
 
   const auto max_cell_id = std::numeric_limits<uint32_t>::max();
@@ -249,9 +251,10 @@ inline CommonPopulationStepResult applyCommonPopulationStep(
     for (const auto& death : dead_cells) {
       result.deaths.push_back(death);
     }
-    std::sort(result.deaths.begin(), result.deaths.end(), [](const auto& lhs, const auto& rhs) {
-      return lhs.id < rhs.id;
-    });
+    CellEvoX::parallel_algorithms::sortMaybeParallel(
+        result.deaths.begin(), result.deaths.end(), [](const auto& lhs, const auto& rhs) {
+          return lhs.id < rhs.id;
+        });
   }
 
   {

--- a/CellEvoX/include/systems/SimulationEngine3DCapacity.hpp
+++ b/CellEvoX/include/systems/SimulationEngine3DCapacity.hpp
@@ -37,6 +37,8 @@ class SimulationEngine3DCapacity {
 
   void initializePopulationPositions();
   void rebuildSpatialState();
+  void updateSpatialState(
+      const CellEvoX::systems::CommonPopulationStepResult& step_result);
   void assignBirthPositions(
       const std::vector<CellEvoX::systems::CommonBirthEvent>& births);
   void mechanicalRelaxationStep();
@@ -77,6 +79,18 @@ class SimulationEngine3DCapacity {
   std::vector<float> id_pos_y_;
   std::vector<float> id_pos_z_;
   std::vector<uint32_t> id_to_spatial_index_;
+  std::vector<uint8_t> dead_spatial_flags_;
+  std::vector<size_t> survivor_offsets_;
+  std::vector<uint32_t> next_cell_ids_;
+  std::vector<float> next_pos_x_;
+  std::vector<float> next_pos_y_;
+  std::vector<float> next_pos_z_;
+  std::vector<float> mech_read_x_;
+  std::vector<float> mech_read_y_;
+  std::vector<float> mech_read_z_;
+  std::vector<float> mech_write_x_;
+  std::vector<float> mech_write_y_;
+  std::vector<float> mech_write_z_;
 
   std::ofstream memory_log_file;
 };

--- a/CellEvoX/include/utils/ParallelAlgorithms.hpp
+++ b/CellEvoX/include/utils/ParallelAlgorithms.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <iterator>
+
+#include <tbb/parallel_sort.h>
+
+namespace CellEvoX::parallel_algorithms {
+
+inline constexpr std::ptrdiff_t kParallelSortMinItems = 2048;
+
+template <typename RandomIt, typename Compare>
+void sortMaybeParallel(RandomIt first, RandomIt last, Compare compare) {
+  const auto count = std::distance(first, last);
+  if (count < kParallelSortMinItems) {
+    std::sort(first, last, compare);
+    return;
+  }
+
+  tbb::parallel_sort(first, last, compare);
+}
+
+template <typename RandomIt>
+void sortMaybeParallel(RandomIt first, RandomIt last) {
+  sortMaybeParallel(first, last, std::less<>{});
+}
+
+}  // namespace CellEvoX::parallel_algorithms

--- a/CellEvoX/src/spatial/SpatialHashGrid.cpp
+++ b/CellEvoX/src/spatial/SpatialHashGrid.cpp
@@ -6,7 +6,10 @@
 #include <vector>
 
 #include <tbb/blocked_range.h>
+#include <tbb/enumerable_thread_specific.h>
 #include <tbb/parallel_for.h>
+
+#include "utils/ParallelAlgorithms.hpp"
 
 namespace {
 
@@ -14,6 +17,8 @@ struct HashedCellEntry {
   int64_t voxel_hash;
   uint32_t cell_id;
 };
+
+constexpr int64_t kMaxDenseVoxelRanges = 1'048'576;
 
 }  // namespace
 
@@ -32,7 +37,9 @@ void SpatialHashGrid::rebuild(const std::vector<uint32_t>& ids,
   const size_t count = ids.size();
   sorted_ids_.clear();
   cell_voxel_.clear();
+  dense_voxel_ranges_.clear();
   voxel_ranges_.clear();
+  use_dense_ranges_ = false;
 
   if (count == 0) {
     return;
@@ -40,6 +47,51 @@ void SpatialHashGrid::rebuild(const std::vector<uint32_t>& ids,
 
   if (px.size() != count || py.size() != count || pz.size() != count) {
     throw std::invalid_argument("SpatialHashGrid::rebuild received mismatched array sizes");
+  }
+
+  const int64_t dense_voxel_count = static_cast<int64_t>(grid_dim_) * grid_dim_ * grid_dim_;
+  if (dense_voxel_count > 0 && dense_voxel_count <= kMaxDenseVoxelRanges) {
+    const size_t voxel_count = static_cast<size_t>(dense_voxel_count);
+    use_dense_ranges_ = true;
+    sorted_ids_.resize(count);
+    cell_voxel_.resize(count);
+    dense_voxel_ranges_.assign(voxel_count, {0, 0});
+
+    tbb::enumerable_thread_specific<std::vector<int32_t>> local_counts(
+        [voxel_count] { return std::vector<int32_t>(voxel_count, 0); });
+
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, count), [&](const tbb::blocked_range<size_t>& range) {
+      auto& counts = local_counts.local();
+      for (size_t i = range.begin(); i != range.end(); ++i) {
+        const int ix = clampVoxelIndex(static_cast<int>(std::floor(px[i] / voxel_size_)));
+        const int iy = clampVoxelIndex(static_cast<int>(std::floor(py[i] / voxel_size_)));
+        const int iz = clampVoxelIndex(static_cast<int>(std::floor(pz[i] / voxel_size_)));
+        const auto voxel = static_cast<int32_t>(hashVoxel(ix, iy, iz));
+        cell_voxel_[i] = voxel;
+        ++counts[static_cast<size_t>(voxel)];
+      }
+    });
+
+    std::vector<int32_t> voxel_counts(voxel_count, 0);
+    for (const auto& counts : local_counts) {
+      for (size_t voxel = 0; voxel < voxel_count; ++voxel) {
+        voxel_counts[voxel] += counts[voxel];
+      }
+    }
+
+    int32_t offset = 0;
+    for (size_t voxel = 0; voxel < voxel_count; ++voxel) {
+      const int32_t begin = offset;
+      offset += voxel_counts[voxel];
+      dense_voxel_ranges_[voxel] = {begin, offset};
+      voxel_counts[voxel] = begin;
+    }
+
+    for (size_t i = 0; i < count; ++i) {
+      const auto voxel = static_cast<size_t>(cell_voxel_[i]);
+      sorted_ids_[static_cast<size_t>(voxel_counts[voxel]++)] = ids[i];
+    }
+    return;
   }
 
   std::vector<HashedCellEntry> hashed_cells(count);
@@ -54,7 +106,7 @@ void SpatialHashGrid::rebuild(const std::vector<uint32_t>& ids,
     }
   });
 
-  std::sort(
+  CellEvoX::parallel_algorithms::sortMaybeParallel(
       hashed_cells.begin(),
       hashed_cells.end(),
       [](const HashedCellEntry& lhs, const HashedCellEntry& rhs) {
@@ -68,14 +120,18 @@ void SpatialHashGrid::rebuild(const std::vector<uint32_t>& ids,
   cell_voxel_.resize(count);
   voxel_ranges_.reserve(count);
 
+  tbb::parallel_for(tbb::blocked_range<size_t>(0, count), [&](const tbb::blocked_range<size_t>& range) {
+    for (size_t i = range.begin(); i != range.end(); ++i) {
+      sorted_ids_[i] = hashed_cells[i].cell_id;
+      cell_voxel_[i] = static_cast<int32_t>(hashed_cells[i].voxel_hash);
+    }
+  });
+
   int64_t current_hash = hashed_cells.front().voxel_hash;
   int32_t range_begin = 0;
 
   // O(N) linear scan over sorted voxel buckets.
   for (size_t i = 0; i < count; ++i) {
-    sorted_ids_[i] = hashed_cells[i].cell_id;
-    cell_voxel_[i] = static_cast<int32_t>(hashed_cells[i].voxel_hash);
-
     if (hashed_cells[i].voxel_hash != current_hash) {
       voxel_ranges_[current_hash] = {range_begin, static_cast<int32_t>(i)};
       current_hash = hashed_cells[i].voxel_hash;

--- a/CellEvoX/src/systems/SimulationEngine3DCapacity.cpp
+++ b/CellEvoX/src/systems/SimulationEngine3DCapacity.cpp
@@ -3,6 +3,7 @@
 #include <spdlog/spdlog.h>
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
+#include <tbb/parallel_scan.h>
 
 #include <algorithm>
 #include <chrono>
@@ -17,6 +18,8 @@
 
 #include "io/PopulationSnapshotIO.hpp"
 #include "systems/CommonPopulationStep.hpp"
+#include "utils/ParallelAlgorithms.hpp"
+#include "utils/PhaseProfiler.hpp"
 #ifdef _WIN32
 #ifndef NOMINMAX
 #define NOMINMAX
@@ -36,6 +39,35 @@ int tauSnapshotIndex(double tau_value) {
 }
 
 constexpr uint32_t kInvalidSpatialIndex = std::numeric_limits<uint32_t>::max();
+
+struct SurvivorOffsetScan {
+  const std::vector<uint8_t>& dead_flags;
+  std::vector<size_t>& offsets;
+  size_t sum{0};
+
+  SurvivorOffsetScan(const std::vector<uint8_t>& dead_flags, std::vector<size_t>& offsets)
+      : dead_flags(dead_flags), offsets(offsets) {}
+
+  SurvivorOffsetScan(SurvivorOffsetScan& other, tbb::split)
+      : dead_flags(other.dead_flags), offsets(other.offsets) {}
+
+  template <typename Tag>
+  void operator()(const tbb::blocked_range<size_t>& range, Tag) {
+    size_t running = sum;
+    for (size_t i = range.begin(); i != range.end(); ++i) {
+      if (dead_flags[i] == 0) {
+        if (Tag::is_final_scan()) {
+          offsets[i] = running;
+        }
+        ++running;
+      }
+    }
+    sum = running;
+  }
+
+  void reverse_join(SurvivorOffsetScan& rhs) { sum += rhs.sum; }
+  void assign(SurvivorOffsetScan& rhs) { sum = rhs.sum; }
+};
 
 }  // namespace
 
@@ -183,30 +215,47 @@ ecs::Run SimulationEngine3DCapacity::run(uint32_t steps, bool run_postprocessing
 }
 
 void SimulationEngine3DCapacity::step() {
+  CELLEVOX_PROFILE_PHASE("3d_capacity_step_total");
   tau += config->tau_step;
-  const auto step_result = CellEvoX::systems::applyCommonPopulationStep(cells,
-                                                                        cells_graveyard,
-                                                                        *config,
-                                                                        available_mutation_types,
-                                                                        total_mutation_probability,
-                                                                        actual_population,
-                                                                        total_deaths,
-                                                                        tau,
-                                                                        event_rng_);
 
-  assignBirthPositions(step_result.births);
-  rebuildSpatialState();
-  mechanicalRelaxationStep();
+  CellEvoX::systems::CommonPopulationStepResult step_result;
+  {
+    CELLEVOX_PROFILE_PHASE("3d_capacity_common_population_step");
+    step_result = CellEvoX::systems::applyCommonPopulationStep(cells,
+                                                               cells_graveyard,
+                                                               *config,
+                                                               available_mutation_types,
+                                                               total_mutation_probability,
+                                                               actual_population,
+                                                               total_deaths,
+                                                               tau,
+                                                               event_rng_);
+  }
+
+  {
+    CELLEVOX_PROFILE_PHASE("3d_capacity_assign_birth_positions");
+    assignBirthPositions(step_result.births);
+  }
+  {
+    CELLEVOX_PROFILE_PHASE("3d_capacity_update_spatial_state");
+    updateSpatialState(step_result);
+  }
+  {
+    CELLEVOX_PROFILE_PHASE("3d_capacity_mechanical_relaxation");
+    mechanicalRelaxationStep();
+  }
 
   const int current_tau = tauSnapshotIndex(tau);
   if (config->stat_res > 0 && current_tau % config->stat_res == 0 &&
       current_tau != last_stat_snapshot_tau) {
+    CELLEVOX_PROFILE_PHASE("3d_capacity_stat_snapshot");
     takeStatSnapshot();
     last_stat_snapshot_tau = current_tau;
   }
 
   if (config->popul_res > 0 && current_tau % config->popul_res == 0 &&
       current_tau != last_population_snapshot_tau) {
+    CELLEVOX_PROFILE_PHASE("3d_capacity_population_snapshot");
     takePopulationSnapshot();
     last_population_snapshot_tau = current_tau;
   }
@@ -215,12 +264,14 @@ void SimulationEngine3DCapacity::step() {
       current_tau > 0 &&
       current_tau % config->graveyard_pruning_interval == 0 &&
       current_tau != last_pruning_tau) {
+    CELLEVOX_PROFILE_PHASE("3d_capacity_graveyard_pruning");
     pruneGraveyard();
     last_pruning_tau = current_tau;
   }
 
   if (config->stat_res > 0 && current_tau % config->stat_res == 0 &&
       current_tau != last_memory_log_tau) {
+    CELLEVOX_PROFILE_PHASE("3d_capacity_memory_log");
     logMemoryUsage();
     last_memory_log_tau = current_tau;
   }
@@ -261,38 +312,154 @@ void SimulationEngine3DCapacity::initializePopulationPositions() {
 }
 
 void SimulationEngine3DCapacity::rebuildSpatialState() {
-  for (uint32_t id : spatial_state_.cell_ids) {
-    if (id < id_to_spatial_index_.size()) {
-      id_to_spatial_index_[id] = kInvalidSpatialIndex;
-    }
-  }
+  tbb::parallel_for(
+      tbb::blocked_range<size_t>(0, spatial_state_.cell_ids.size()),
+      [&](const tbb::blocked_range<size_t>& range) {
+        for (size_t i = range.begin(); i != range.end(); ++i) {
+          const uint32_t id = spatial_state_.cell_ids[i];
+          if (id < id_to_spatial_index_.size()) {
+            id_to_spatial_index_[id] = kInvalidSpatialIndex;
+          }
+        }
+      });
 
   spatial_state_.cell_ids.clear();
-  spatial_state_.pos_x.clear();
-  spatial_state_.pos_y.clear();
-  spatial_state_.pos_z.clear();
-
   spatial_state_.cell_ids.reserve(cells.size());
   for (const auto& cell_entry : cells) {
     spatial_state_.cell_ids.push_back(cell_entry.first);
   }
-  std::sort(spatial_state_.cell_ids.begin(), spatial_state_.cell_ids.end());
+  CellEvoX::parallel_algorithms::sortMaybeParallel(
+      spatial_state_.cell_ids.begin(), spatial_state_.cell_ids.end());
 
-  spatial_state_.pos_x.reserve(spatial_state_.cell_ids.size());
-  spatial_state_.pos_y.reserve(spatial_state_.cell_ids.size());
-  spatial_state_.pos_z.reserve(spatial_state_.cell_ids.size());
+  const size_t count = spatial_state_.cell_ids.size();
+  spatial_state_.pos_x.resize(count);
+  spatial_state_.pos_y.resize(count);
+  spatial_state_.pos_z.resize(count);
 
-  for (size_t i = 0; i < spatial_state_.cell_ids.size(); ++i) {
-    const uint32_t id = spatial_state_.cell_ids[i];
-    ensurePositionCapacity(id);
-    spatial_state_.pos_x.push_back(id_pos_x_[id]);
-    spatial_state_.pos_y.push_back(id_pos_y_[id]);
-    spatial_state_.pos_z.push_back(id_pos_z_[id]);
-    id_to_spatial_index_[id] = static_cast<uint32_t>(i);
+  if (count > 0) {
+    ensurePositionCapacity(spatial_state_.cell_ids.back());
   }
+
+  tbb::parallel_for(
+      tbb::blocked_range<size_t>(0, count),
+      [&](const tbb::blocked_range<size_t>& range) {
+        for (size_t i = range.begin(); i != range.end(); ++i) {
+          const uint32_t id = spatial_state_.cell_ids[i];
+          spatial_state_.pos_x[i] = id_pos_x_[id];
+          spatial_state_.pos_y[i] = id_pos_y_[id];
+          spatial_state_.pos_z[i] = id_pos_z_[id];
+          id_to_spatial_index_[id] = static_cast<uint32_t>(i);
+        }
+      });
 
   spatial_grid_.rebuild(
       spatial_state_.cell_ids, spatial_state_.pos_x, spatial_state_.pos_y, spatial_state_.pos_z);
+}
+
+void SimulationEngine3DCapacity::updateSpatialState(
+    const CellEvoX::systems::CommonPopulationStepResult& step_result) {
+  const auto& births = step_result.births;
+  const auto& deaths = step_result.deaths;
+  if (births.empty() && deaths.empty()) {
+    return;
+  }
+
+  if (deaths.empty()) {
+    const size_t old_count = spatial_state_.cell_ids.size();
+    const size_t new_count = old_count + births.size();
+    spatial_state_.cell_ids.resize(new_count);
+    spatial_state_.pos_x.resize(new_count);
+    spatial_state_.pos_y.resize(new_count);
+    spatial_state_.pos_z.resize(new_count);
+
+    if (!births.empty()) {
+      ensurePositionCapacity(births.back().id);
+    }
+
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, births.size()),
+        [&](const tbb::blocked_range<size_t>& range) {
+          for (size_t i = range.begin(); i != range.end(); ++i) {
+            const uint32_t id = births[i].id;
+            const size_t target = old_count + i;
+            spatial_state_.cell_ids[target] = id;
+            spatial_state_.pos_x[target] = id_pos_x_[id];
+            spatial_state_.pos_y[target] = id_pos_y_[id];
+            spatial_state_.pos_z[target] = id_pos_z_[id];
+            id_to_spatial_index_[id] = static_cast<uint32_t>(target);
+          }
+        });
+    return;
+  }
+
+  const size_t old_count = spatial_state_.cell_ids.size();
+  dead_spatial_flags_.assign(old_count, uint8_t{0});
+  survivor_offsets_.resize(old_count);
+
+  tbb::parallel_for(
+      tbb::blocked_range<size_t>(0, deaths.size()),
+      [&](const tbb::blocked_range<size_t>& range) {
+        for (size_t i = range.begin(); i != range.end(); ++i) {
+          const uint32_t id = deaths[i].id;
+          if (id >= id_to_spatial_index_.size()) {
+            continue;
+          }
+          const uint32_t spatial_index = id_to_spatial_index_[id];
+          if (spatial_index != kInvalidSpatialIndex && spatial_index < old_count) {
+            dead_spatial_flags_[spatial_index] = 1;
+          }
+          id_to_spatial_index_[id] = kInvalidSpatialIndex;
+        }
+      });
+
+  SurvivorOffsetScan offset_scan(dead_spatial_flags_, survivor_offsets_);
+  tbb::parallel_scan(tbb::blocked_range<size_t>(0, old_count), offset_scan);
+  const size_t survivor_count = offset_scan.sum;
+  const size_t new_count = survivor_count + births.size();
+
+  next_cell_ids_.resize(new_count);
+  next_pos_x_.resize(new_count);
+  next_pos_y_.resize(new_count);
+  next_pos_z_.resize(new_count);
+
+  tbb::parallel_for(
+      tbb::blocked_range<size_t>(0, old_count),
+      [&](const tbb::blocked_range<size_t>& range) {
+        for (size_t i = range.begin(); i != range.end(); ++i) {
+          if (dead_spatial_flags_[i] != 0) {
+            continue;
+          }
+          const size_t target = survivor_offsets_[i];
+          const uint32_t id = spatial_state_.cell_ids[i];
+          next_cell_ids_[target] = id;
+          next_pos_x_[target] = spatial_state_.pos_x[i];
+          next_pos_y_[target] = spatial_state_.pos_y[i];
+          next_pos_z_[target] = spatial_state_.pos_z[i];
+          id_to_spatial_index_[id] = static_cast<uint32_t>(target);
+        }
+      });
+
+  if (!births.empty()) {
+    ensurePositionCapacity(births.back().id);
+  }
+  tbb::parallel_for(
+      tbb::blocked_range<size_t>(0, births.size()),
+      [&](const tbb::blocked_range<size_t>& range) {
+        for (size_t i = range.begin(); i != range.end(); ++i) {
+          const uint32_t id = births[i].id;
+          const size_t target = survivor_count + i;
+          next_cell_ids_[target] = id;
+          next_pos_x_[target] = id_pos_x_[id];
+          next_pos_y_[target] = id_pos_y_[id];
+          next_pos_z_[target] = id_pos_z_[id];
+          id_to_spatial_index_[id] = static_cast<uint32_t>(target);
+        }
+      });
+
+  spatial_state_.cell_ids.swap(next_cell_ids_);
+  spatial_state_.pos_x.swap(next_pos_x_);
+  spatial_state_.pos_y.swap(next_pos_y_);
+  spatial_state_.pos_z.swap(next_pos_z_);
 }
 
 void SimulationEngine3DCapacity::assignBirthPositions(
@@ -336,23 +503,32 @@ void SimulationEngine3DCapacity::mechanicalRelaxationStep() {
   const float interaction_radius = 2.0f * CELL_RADIUS;
   const float interaction_radius_sq = interaction_radius * interaction_radius;
 
-  std::vector<float> read_x = spatial_state_.pos_x;
-  std::vector<float> read_y = spatial_state_.pos_y;
-  std::vector<float> read_z = spatial_state_.pos_z;
-  std::vector<float> write_x = read_x;
-  std::vector<float> write_y = read_y;
-  std::vector<float> write_z = read_z;
+  mech_read_x_.resize(count);
+  mech_read_y_.resize(count);
+  mech_read_z_.resize(count);
+  mech_write_x_.resize(count);
+  mech_write_y_.resize(count);
+  mech_write_z_.resize(count);
+  tbb::parallel_for(
+      tbb::blocked_range<size_t>(0, count),
+      [&](const tbb::blocked_range<size_t>& range) {
+        for (size_t i = range.begin(); i != range.end(); ++i) {
+          mech_read_x_[i] = spatial_state_.pos_x[i];
+          mech_read_y_[i] = spatial_state_.pos_y[i];
+          mech_read_z_[i] = spatial_state_.pos_z[i];
+        }
+      });
 
   for (int substep = 0; substep < config->mech_substeps; ++substep) {
-    spatial_grid_.rebuild(spatial_state_.cell_ids, read_x, read_y, read_z);
+    spatial_grid_.rebuild(spatial_state_.cell_ids, mech_read_x_, mech_read_y_, mech_read_z_);
 
     tbb::parallel_for(
         tbb::blocked_range<size_t>(0, count),
         [&](const tbb::blocked_range<size_t>& range) {
           for (size_t i = range.begin(); i != range.end(); ++i) {
-            const float xi = read_x[i];
-            const float yi = read_y[i];
-            const float zi = read_z[i];
+            const float xi = mech_read_x_[i];
+            const float yi = mech_read_y_[i];
+            const float zi = mech_read_z_[i];
 
             Eigen::Vector3f force = Eigen::Vector3f::Zero();
             spatial_grid_.queryRadius(xi, yi, zi, interaction_radius, [&](uint32_t neighbor_id) {
@@ -361,9 +537,9 @@ void SimulationEngine3DCapacity::mechanicalRelaxationStep() {
                 return;
               }
 
-              const float dx = xi - read_x[neighbor_index];
-              const float dy = yi - read_y[neighbor_index];
-              const float dz = zi - read_z[neighbor_index];
+              const float dx = xi - mech_read_x_[neighbor_index];
+              const float dy = yi - mech_read_y_[neighbor_index];
+              const float dz = zi - mech_read_z_[neighbor_index];
               const float dist_sq = dx * dx + dy * dy + dz * dz;
               if (dist_sq <= 1e-12f || dist_sq >= interaction_radius_sq) {
                 return;
@@ -381,20 +557,20 @@ void SimulationEngine3DCapacity::mechanicalRelaxationStep() {
               force.z() += scale * dz;
             });
 
-            write_x[i] = clampToDomain(xi + force.x() * config->mech_dt);
-            write_y[i] = clampToDomain(yi + force.y() * config->mech_dt);
-            write_z[i] = clampToDomain(zi + force.z() * config->mech_dt);
+            mech_write_x_[i] = clampToDomain(xi + force.x() * config->mech_dt);
+            mech_write_y_[i] = clampToDomain(yi + force.y() * config->mech_dt);
+            mech_write_z_[i] = clampToDomain(zi + force.z() * config->mech_dt);
           }
         });
 
-    read_x.swap(write_x);
-    read_y.swap(write_y);
-    read_z.swap(write_z);
+    mech_read_x_.swap(mech_write_x_);
+    mech_read_y_.swap(mech_write_y_);
+    mech_read_z_.swap(mech_write_z_);
   }
 
-  spatial_state_.pos_x = std::move(read_x);
-  spatial_state_.pos_y = std::move(read_y);
-  spatial_state_.pos_z = std::move(read_z);
+  spatial_state_.pos_x.swap(mech_read_x_);
+  spatial_state_.pos_y.swap(mech_read_y_);
+  spatial_state_.pos_z.swap(mech_read_z_);
 
   tbb::parallel_for(
       tbb::blocked_range<size_t>(0, count),
@@ -434,7 +610,7 @@ void SimulationEngine3DCapacity::takeStatSnapshot() {
   for (const auto& cell : cells) {
     sorted_keys.push_back(cell.first);
   }
-  std::sort(sorted_keys.begin(), sorted_keys.end());
+  CellEvoX::parallel_algorithms::sortMaybeParallel(sorted_keys.begin(), sorted_keys.end());
 
   for (uint32_t key : sorted_keys) {
     CellMap::const_accessor accessor;

--- a/CellEvoX/tests/test_simulation.cpp
+++ b/CellEvoX/tests/test_simulation.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <cstdlib>
 #include <map>
+#include <numeric>
 #include <random>
 #include <cmath>
 #include <cstring>
@@ -177,6 +178,39 @@ TEST_CASE("SpatialHashGrid returns neighbors from nearby voxels", "[SpatialHashG
 
     std::sort(neighbors.begin(), neighbors.end());
     REQUIRE(neighbors == std::vector<uint32_t>{10, 11});
+}
+
+TEST_CASE("SpatialHashGrid handles large rebuilds through the parallel sort path", "[SpatialHashGrid][Parallel]") {
+    constexpr uint32_t cell_count = 4096;
+    SpatialHashGrid grid(2.0f, 64.0f);
+    std::vector<uint32_t> ids;
+    std::vector<float> px;
+    std::vector<float> py;
+    std::vector<float> pz;
+    ids.reserve(cell_count);
+    px.reserve(cell_count);
+    py.reserve(cell_count);
+    pz.reserve(cell_count);
+
+    for (uint32_t i = 0; i < cell_count; ++i) {
+        const uint32_t id = cell_count - i;
+        ids.push_back(id);
+        px.push_back(static_cast<float>((i * 17) % 63));
+        py.push_back(static_cast<float>((i * 31) % 63));
+        pz.push_back(static_cast<float>((i * 47) % 63));
+    }
+
+    grid.rebuild(ids, px, py, pz);
+
+    std::vector<uint32_t> neighbors;
+    grid.queryRadius(32.0f, 32.0f, 32.0f, 128.0f, [&](uint32_t id) {
+        neighbors.push_back(id);
+    });
+
+    std::sort(neighbors.begin(), neighbors.end());
+    std::vector<uint32_t> expected(cell_count);
+    std::iota(expected.begin(), expected.end(), 1u);
+    REQUIRE(neighbors == expected);
 }
 
 TEST_CASE("Cell Initialization and Inheritance", "[Cell]") {
@@ -1094,6 +1128,49 @@ TEST_CASE("SimulationEngine3DCapacity writes full mutation payload snapshots whe
     REQUIRE(std::all_of(mutations.begin(), mutations.end(), [](const auto& mutation) {
         return mutation.mutation_type == 2;
     }));
+}
+
+TEST_CASE("SimulationEngine3DCapacity mechanics are deterministic across worker counts", "[SimulationEngine3DCapacity][Determinism][Parallel]") {
+    auto make_config = [](const std::string& output_path) {
+        auto config = std::make_shared<SimulationConfig>();
+        config->sim_type = SimulationType::SPATIAL_3D_CAPACITY;
+        config->tau_step = 1.0;
+        config->seed = 2026;
+        config->initial_population = 64;
+        config->env_capacity = 0;
+        config->steps = 1;
+        config->stat_res = 1;
+        config->popul_res = 1;
+        config->output_path = output_path;
+        config->spatial_domain_size = 8.0f;
+        config->spring_constant = 0.35f;
+        config->mech_dt = 0.08f;
+        config->mech_substeps = 3;
+        config->epsilon = 0.1f;
+        config->verbosity = 0;
+        return config;
+    };
+
+    auto run_snapshot = [&](int parallelism, const std::string& output_name) {
+        auto config = make_config(testTempString(output_name));
+        std::filesystem::remove_all(config->output_path);
+        std::filesystem::create_directories(config->output_path);
+
+        {
+            tbb::global_control control(tbb::global_control::max_allowed_parallelism, parallelism);
+            SimulationEngine3DCapacity engine(config);
+            auto runData = engine.run(config->steps, false);
+            REQUIRE(runData.cells.size() == config->initial_population);
+        }
+
+        return read_binary_file(
+            std::filesystem::path(config->output_path) / "population_data" / "population_generation_1.bin");
+    };
+
+    const auto single_thread_snapshot = run_snapshot(1, "test_sim_3d_capacity_parallel_det_1");
+    const auto five_thread_snapshot = run_snapshot(5, "test_sim_3d_capacity_parallel_det_5");
+
+    REQUIRE(single_thread_snapshot == five_thread_snapshot);
 }
 
 TEST_CASE("SimulationEngine3D grows from a sparse neutral state", "[SimulationEngine3D]") {


### PR DESCRIPTION
## Summary
- add a reusable parallel-sort helper for common population event ordering
- speed up 3D spatial hashing with a dense voxel-range path where domain sizes are reasonable
- reduce 3D capacity per-step overhead with incremental spatial state, parallel compaction, and reusable mechanics buffers
- add regression coverage for large spatial rebuilds and deterministic 3D capacity mechanics across worker counts

## Branching
This is stacked on `perf/2d-simulation-profiling` so the PR diff contains only the 3D capacity/runtime optimization commit.

## Verification
- `git diff --check`
- `CellEvoX/build_skip_gui/bin/CellEvoXTests "~[benchmark]" --durations yes`

## Perf check
Median targeted before/after probes showed no degradation:
- 2D stochastic eventful: 1.28x faster
- 3D density eventful: 2.30x faster
- 3D capacity eventful: 2.52x faster
